### PR TITLE
Add contract validation endpoint with tests

### DIFF
--- a/backend/src/contracts/contracts.controller.spec.ts
+++ b/backend/src/contracts/contracts.controller.spec.ts
@@ -1,0 +1,174 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ContractsController } from "./contracts.controller";
+import { ContractsService } from "./contracts.service";
+
+describe("ContractsController", () => {
+  let controller: ContractsController;
+  let service: ContractsService;
+
+  const mockValidationResult = {
+    valid: true,
+    files: [
+      {
+        filePath: "/path/to/contract1.yml",
+        fileName: "contract1.yml",
+        valid: true,
+      },
+      {
+        filePath: "/path/to/contract2.yml",
+        fileName: "contract2.yml",
+        valid: true,
+      },
+    ],
+  };
+
+  const mockInvalidValidationResult = {
+    valid: false,
+    files: [
+      {
+        filePath: "/path/to/valid-contract.yml",
+        fileName: "valid-contract.yml",
+        valid: true,
+      },
+      {
+        filePath: "/path/to/invalid-contract.yml",
+        fileName: "invalid-contract.yml",
+        valid: false,
+        errors: [
+          {
+            path: "id",
+            message: "Contract id is required",
+          },
+        ],
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ContractsController],
+      providers: [
+        {
+          provide: ContractsService,
+          useValue: {
+            getAllContracts: jest.fn(),
+            validateContracts: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ContractsController>(ContractsController);
+    service = module.get<ContractsService>(ContractsService);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe("validateContracts", () => {
+    it("should return validation results for all contracts", async () => {
+      jest
+        .spyOn(service, "validateContracts")
+        .mockResolvedValue(mockValidationResult);
+
+      const result = await controller.validateContracts();
+
+      expect(result).toEqual(mockValidationResult);
+      expect(service.validateContracts).toHaveBeenCalled();
+    });
+
+    it("should return valid: true when all contracts are valid", async () => {
+      jest
+        .spyOn(service, "validateContracts")
+        .mockResolvedValue(mockValidationResult);
+
+      const result = await controller.validateContracts();
+
+      expect(result.valid).toBe(true);
+      expect(result.files.every((file) => file.valid)).toBe(true);
+    });
+
+    it("should return valid: false when any contract is invalid", async () => {
+      jest
+        .spyOn(service, "validateContracts")
+        .mockResolvedValue(mockInvalidValidationResult);
+
+      const result = await controller.validateContracts();
+
+      expect(result.valid).toBe(false);
+      expect(result.files.some((file) => !file.valid)).toBe(true);
+    });
+
+    it("should include error details for invalid contracts", async () => {
+      jest
+        .spyOn(service, "validateContracts")
+        .mockResolvedValue(mockInvalidValidationResult);
+
+      const result = await controller.validateContracts();
+
+      const invalidFile = result.files.find((file) => !file.valid);
+      expect(invalidFile).toBeDefined();
+      expect(invalidFile!.errors).toBeDefined();
+      expect(invalidFile!.errors!.length).toBeGreaterThan(0);
+      expect(invalidFile!.errors![0]).toHaveProperty("path");
+      expect(invalidFile!.errors![0]).toHaveProperty("message");
+    });
+
+    it("should include file paths and names in validation results", async () => {
+      jest
+        .spyOn(service, "validateContracts")
+        .mockResolvedValue(mockValidationResult);
+
+      const result = await controller.validateContracts();
+
+      expect(result.files.length).toBeGreaterThan(0);
+      result.files.forEach((file) => {
+        expect(file.filePath).toBeDefined();
+        expect(file.fileName).toBeDefined();
+        expect(file.valid).toBeDefined();
+      });
+    });
+
+    it("should handle empty contract list", async () => {
+      jest.spyOn(service, "validateContracts").mockResolvedValue({
+        valid: true,
+        files: [],
+      });
+
+      const result = await controller.validateContracts();
+
+      expect(result.valid).toBe(true);
+      expect(result.files).toEqual([]);
+    });
+
+    it("should propagate errors from the service", async () => {
+      jest
+        .spyOn(service, "validateContracts")
+        .mockRejectedValue(new Error("Service error"));
+
+      await expect(controller.validateContracts()).rejects.toThrow(
+        "Service error",
+      );
+    });
+  });
+
+  describe("getAllContracts", () => {
+    it("should return all contracts from service", async () => {
+      const mockContracts = [
+        {
+          fileName: "contract1.yml",
+          filePath: "/path/to/contract1.yml",
+          content: { id: "test", type: "service" },
+        },
+      ];
+
+      jest.spyOn(service, "getAllContracts").mockResolvedValue(mockContracts);
+
+      const result = await controller.getAllContracts();
+
+      expect(result).toEqual(mockContracts);
+      expect(service.getAllContracts).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/contracts/contracts.controller.ts
+++ b/backend/src/contracts/contracts.controller.ts
@@ -9,4 +9,9 @@ export class ContractsController {
   async getAllContracts() {
     return this.contractsService.getAllContracts();
   }
+
+  @Get("validate")
+  async validateContracts() {
+    return this.contractsService.validateContracts();
+  }
 }

--- a/backend/src/contracts/contracts.service.spec.ts
+++ b/backend/src/contracts/contracts.service.spec.ts
@@ -18,7 +18,15 @@ describe("ContractsService", () => {
           },
         },
       ],
-    }).compile();
+    })
+      .setLogger({
+        log: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+        debug: jest.fn(),
+        verbose: jest.fn(),
+      })
+      .compile();
 
     service = module.get<ContractsService>(ContractsService);
     configService = module.get<ConfigService>(ConfigService);

--- a/backend/src/contracts/contracts.service.spec.ts
+++ b/backend/src/contracts/contracts.service.spec.ts
@@ -1,0 +1,259 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigService } from "@nestjs/config";
+import { ContractsService } from "./contracts.service";
+import * as path from "path";
+
+describe("ContractsService", () => {
+  let service: ContractsService;
+  let configService: ConfigService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ContractsService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ContractsService>(ContractsService);
+    configService = module.get<ConfigService>(ConfigService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("validateContracts", () => {
+    const testFixturesPath = path.join(__dirname, "test-fixtures");
+
+    it("should validate all contracts and return success for valid contracts", async () => {
+      const validPattern = path.join(testFixturesPath, "valid-*.yml");
+      jest.spyOn(configService, "get").mockReturnValue(validPattern);
+
+      const result = await service.validateContracts();
+
+      expect(result).toBeDefined();
+      expect(result.valid).toBe(true);
+      expect(result.files).toBeDefined();
+      expect(result.files.length).toBeGreaterThan(0);
+      expect(result.files.every((file) => file.valid)).toBe(true);
+    });
+
+    it("should detect invalid contracts and return validation errors", async () => {
+      const invalidPattern = path.join(
+        testFixturesPath,
+        "invalid-missing-id.yml",
+      );
+      jest.spyOn(configService, "get").mockReturnValue(invalidPattern);
+
+      const result = await service.validateContracts();
+
+      expect(result).toBeDefined();
+      expect(result.valid).toBe(false);
+      expect(result.files).toBeDefined();
+      expect(result.files.length).toBe(1);
+      expect(result.files[0].valid).toBe(false);
+      expect(result.files[0].errors).toBeDefined();
+      expect(result.files[0].errors!.length).toBeGreaterThan(0);
+      // Check that there's an error message (Zod format may vary)
+      expect(result.files[0].errors![0].message).toBeTruthy();
+    });
+
+    it("should validate multiple contracts and separate valid from invalid", async () => {
+      const mixedPattern = path.join(testFixturesPath, "*.yml");
+      jest.spyOn(configService, "get").mockReturnValue(mixedPattern);
+
+      const result = await service.validateContracts();
+
+      expect(result).toBeDefined();
+      expect(result.files).toBeDefined();
+      expect(result.files.length).toBeGreaterThan(0);
+
+      const validFiles = result.files.filter((f) => f.valid);
+      const invalidFiles = result.files.filter((f) => !f.valid);
+
+      expect(validFiles.length).toBeGreaterThan(0);
+      expect(invalidFiles.length).toBeGreaterThan(0);
+      expect(result.valid).toBe(false); // Should be false if any file is invalid
+    });
+
+    it("should include file path and name in validation results", async () => {
+      const validPattern = path.join(
+        testFixturesPath,
+        "valid-contract-minimal.yml",
+      );
+      jest.spyOn(configService, "get").mockReturnValue(validPattern);
+
+      const result = await service.validateContracts();
+
+      expect(result.files[0].filePath).toBeDefined();
+      expect(result.files[0].fileName).toBe("valid-contract-minimal.yml");
+    });
+
+    it("should handle missing CONTRACTS_PATH environment variable", async () => {
+      jest.spyOn(configService, "get").mockReturnValue(undefined);
+
+      await expect(service.validateContracts()).rejects.toThrow(
+        "CONTRACTS_PATH environment variable is not set",
+      );
+    });
+
+    it("should return empty array when no contract files found", async () => {
+      const nonExistentPattern = path.join(
+        testFixturesPath,
+        "non-existent-*.yml",
+      );
+      jest.spyOn(configService, "get").mockReturnValue(nonExistentPattern);
+
+      const result = await service.validateContracts();
+
+      expect(result).toBeDefined();
+      expect(result.valid).toBe(true);
+      expect(result.files).toEqual([]);
+    });
+
+    it("should detect contracts with missing type field", async () => {
+      const invalidPattern = path.join(
+        testFixturesPath,
+        "invalid-missing-type.yml",
+      );
+      jest.spyOn(configService, "get").mockReturnValue(invalidPattern);
+
+      const result = await service.validateContracts();
+
+      expect(result.valid).toBe(false);
+      expect(result.files[0].valid).toBe(false);
+      expect(result.files[0].errors).toBeDefined();
+      // Check that there are validation errors present
+      expect(result.files[0].errors!.length).toBeGreaterThan(0);
+    });
+
+    it("should detect contracts with missing category field", async () => {
+      const invalidPattern = path.join(
+        testFixturesPath,
+        "invalid-missing-category.yml",
+      );
+      jest.spyOn(configService, "get").mockReturnValue(invalidPattern);
+
+      const result = await service.validateContracts();
+
+      expect(result.valid).toBe(false);
+      expect(result.files[0].valid).toBe(false);
+      expect(result.files[0].errors).toBeDefined();
+    });
+
+    it("should detect contracts with missing description field", async () => {
+      const invalidPattern = path.join(
+        testFixturesPath,
+        "invalid-missing-description.yml",
+      );
+      jest.spyOn(configService, "get").mockReturnValue(invalidPattern);
+
+      const result = await service.validateContracts();
+
+      expect(result.valid).toBe(false);
+      expect(result.files[0].valid).toBe(false);
+      expect(result.files[0].errors).toBeDefined();
+    });
+
+    it("should detect invalid part definitions without id", async () => {
+      const invalidPattern = path.join(
+        testFixturesPath,
+        "invalid-part-without-id.yml",
+      );
+      jest.spyOn(configService, "get").mockReturnValue(invalidPattern);
+
+      const result = await service.validateContracts();
+
+      expect(result.valid).toBe(false);
+      expect(result.files[0].valid).toBe(false);
+      expect(result.files[0].errors).toBeDefined();
+    });
+
+    it("should detect invalid part definitions without type", async () => {
+      const invalidPattern = path.join(
+        testFixturesPath,
+        "invalid-part-without-type.yml",
+      );
+      jest.spyOn(configService, "get").mockReturnValue(invalidPattern);
+
+      const result = await service.validateContracts();
+
+      expect(result.valid).toBe(false);
+      expect(result.files[0].valid).toBe(false);
+      expect(result.files[0].errors).toBeDefined();
+    });
+
+    it("should detect invalid dependencies without module_id", async () => {
+      const invalidPattern = path.join(
+        testFixturesPath,
+        "invalid-dependency-without-module-id.yml",
+      );
+      jest.spyOn(configService, "get").mockReturnValue(invalidPattern);
+
+      const result = await service.validateContracts();
+
+      expect(result.valid).toBe(false);
+      expect(result.files[0].valid).toBe(false);
+      expect(result.files[0].errors).toBeDefined();
+    });
+
+    it("should detect invalid dependencies without parts", async () => {
+      const invalidPattern = path.join(
+        testFixturesPath,
+        "invalid-dependency-without-parts.yml",
+      );
+      jest.spyOn(configService, "get").mockReturnValue(invalidPattern);
+
+      const result = await service.validateContracts();
+
+      expect(result.valid).toBe(false);
+      expect(result.files[0].valid).toBe(false);
+      expect(result.files[0].errors).toBeDefined();
+    });
+
+    it("should detect invalid dependencies with empty parts array", async () => {
+      const invalidPattern = path.join(
+        testFixturesPath,
+        "invalid-dependency-empty-parts.yml",
+      );
+      jest.spyOn(configService, "get").mockReturnValue(invalidPattern);
+
+      const result = await service.validateContracts();
+
+      expect(result.valid).toBe(false);
+      expect(result.files[0].valid).toBe(false);
+      expect(result.files[0].errors).toBeDefined();
+    });
+
+    it("should provide detailed error paths for nested validation errors", async () => {
+      const invalidPattern = path.join(
+        testFixturesPath,
+        "invalid-part-without-id.yml",
+      );
+      jest.spyOn(configService, "get").mockReturnValue(invalidPattern);
+
+      const result = await service.validateContracts();
+
+      expect(result.files[0].errors).toBeDefined();
+      expect(result.files[0].errors!.length).toBeGreaterThan(0);
+      expect(result.files[0].errors![0].path).toBeDefined();
+      expect(result.files[0].errors![0].message).toBeDefined();
+    });
+  });
+
+  describe("getAllContracts", () => {
+    it("should throw error when CONTRACTS_PATH is not set", async () => {
+      jest.spyOn(configService, "get").mockReturnValue(undefined);
+
+      await expect(service.getAllContracts()).rejects.toThrow(
+        "CONTRACTS_PATH environment variable is not set",
+      );
+    });
+  });
+});

--- a/backend/src/contracts/contracts.service.ts
+++ b/backend/src/contracts/contracts.service.ts
@@ -4,6 +4,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as yaml from "js-yaml";
 import { glob } from "glob";
+import { ContractSchema } from "./contract.schema";
 
 @Injectable()
 export class ContractsService {
@@ -60,6 +61,109 @@ export class ContractsService {
     } catch (error) {
       this.logger.error("Error loading contracts:", error.message);
       throw new Error(`Failed to load contracts: ${error.message}`);
+    }
+  }
+
+  async validateContracts(): Promise<{
+    valid: boolean;
+    files: Array<{
+      filePath: string;
+      fileName: string;
+      valid: boolean;
+      errors?: Array<{
+        path: string;
+        message: string;
+      }>;
+    }>;
+  }> {
+    const contractsPath = this.configService.get<string>("CONTRACTS_PATH");
+
+    if (!contractsPath) {
+      this.logger.error("CONTRACTS_PATH environment variable is not set");
+      throw new Error("CONTRACTS_PATH environment variable is not set");
+    }
+
+    this.logger.log(`Validating contracts from: ${contractsPath}`);
+
+    try {
+      // Resolve the glob pattern to find all matching YAML files
+      const files = await glob(contractsPath, {
+        absolute: true,
+      });
+
+      if (files.length === 0) {
+        this.logger.warn(
+          `No contract files found matching pattern: ${contractsPath}`,
+        );
+        return {
+          valid: true,
+          files: [],
+        };
+      }
+
+      this.logger.log(`Validating ${files.length} contract file(s)`);
+
+      const validationResults = [];
+      let allValid = true;
+
+      for (const file of files) {
+        const fileName = path.basename(file);
+        try {
+          const fileContent = fs.readFileSync(file, "utf8");
+          const parsedContract = yaml.load(fileContent);
+
+          // Validate the parsed contract against the schema
+          const validationResult = ContractSchema.safeParse(parsedContract);
+
+          if (validationResult.success) {
+            validationResults.push({
+              filePath: file,
+              fileName,
+              valid: true,
+            });
+            this.logger.log(`✓ Valid: ${fileName}`);
+          } else {
+            allValid = false;
+            const errors = validationResult.error.issues.map((err) => ({
+              path: err.path.join(".") || "root",
+              message: err.message,
+            }));
+
+            validationResults.push({
+              filePath: file,
+              fileName,
+              valid: false,
+              errors,
+            });
+            this.logger.warn(`✗ Invalid: ${fileName}`);
+          }
+        } catch (error) {
+          allValid = false;
+          const errorMessage =
+            error instanceof Error ? error.message : "Unknown error";
+
+          validationResults.push({
+            filePath: file,
+            fileName,
+            valid: false,
+            errors: [
+              {
+                path: "file",
+                message: `Failed to parse YAML: ${errorMessage}`,
+              },
+            ],
+          });
+          this.logger.error(`✗ Parse error in ${fileName}:`, errorMessage);
+        }
+      }
+
+      return {
+        valid: allValid,
+        files: validationResults,
+      };
+    } catch (error) {
+      this.logger.error("Error validating contracts:", error.message);
+      throw new Error(`Failed to validate contracts: ${error.message}`);
     }
   }
 }


### PR DESCRIPTION
Add a new endpoint (`GET /contracts/validate`) to validate contract files against their schema and return detailed validation results, fulfilling PIA-18.

---
Linear Issue: [PIA-18](https://linear.app/piarsoftware/issue/PIA-18/add-endpoint-validating-if-contracts-are-correct)

<a href="https://cursor.com/background-agent?bcId=bc-bcf18b9c-dd69-4652-97e0-ce33e9d885b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bcf18b9c-dd69-4652-97e0-ce33e9d885b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

