### PR TITLE
Validate dependency part types in module

### DIFF
--- a/backend/src/contracts/test-fixtures/invalid-dependency-multiple-type-mismatches.yml
+++ b/backend/src/contracts/test-fixtures/invalid-dependency-multiple-type-mismatches.yml
@@ -1,0 +1,13 @@
+id: test-module-with-multiple-mismatches
+type: controller
+category: api
+description: Test module with multiple dependency part type mismatches
+dependencies:
+  - module_id: users-permissions
+    parts:
+      - part_id: id
+        type: function
+      - part_id: name
+        type: number
+      - part_id: checkPermission
+        type: string

--- a/backend/src/contracts/test-fixtures/invalid-dependency-type-mismatch.yml
+++ b/backend/src/contracts/test-fixtures/invalid-dependency-type-mismatch.yml
@@ -1,0 +1,11 @@
+id: test-module-with-type-mismatch
+type: controller
+category: api
+description: Test module with dependency part type mismatch
+dependencies:
+  - module_id: users-permissions
+    parts:
+      - part_id: id
+        type: function
+      - part_id: name
+        type: string


### PR DESCRIPTION
Add validation to detect and report mismatches in dependency part types to ensure contract consistency.

---
Linear Issue: [PIA-19](https://linear.app/piarsoftware/issue/PIA-19/add-validation-for-types-dependencies-parts)

<a href="https://cursor.com/background-agent?bcId=bc-aa00fcaf-f3aa-4f4e-8007-4488cb31bed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aa00fcaf-f3aa-4f4e-8007-4488cb31bed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

