### PR TITLE
Add step two navigation button and test

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,8 @@ import {
   Stack,
   CircularProgress,
   Alert,
-  Chip
+  Chip,
+  Button
 } from '@mui/material'
 import { useContractsControllerGetAllContracts } from './api/generated/contracts/contracts'
 
@@ -92,6 +93,16 @@ function App() {
                   ))}
                 </Stack>
               )}
+              
+              <Box sx={{ mt: 3, display: 'flex', justifyContent: 'center' }}>
+                <Button 
+                  variant="contained" 
+                  color="primary"
+                  size="large"
+                >
+                  Go to Step 2: Verification
+                </Button>
+              </Box>
             </CardContent>
           </Card>
         </Stack>

--- a/frontend/tests/contracts-list.spec.ts
+++ b/frontend/tests/contracts-list.spec.ts
@@ -186,4 +186,18 @@ test.describe('Contracts List Page', () => {
     expect(serviceContract).toBe(true);
     expect(frontendContract).toBe(true);
   });
+
+  test('should display "Go to Step 2: Verification" button', async ({ page }) => {
+    // Mock API response with sample contracts
+    await page.route('**/api/contracts', async (route) => {
+      await route.fulfill(mockApiResponses.success(mockContracts.validContracts));
+    });
+
+    await contractsPage.navigate();
+    await contractsPage.waitForContractsToLoad();
+
+    // Verify the "Go to Step 2" button is visible
+    await expect(contractsPage.goToStep2Button).toBeVisible();
+    await expect(contractsPage.goToStep2Button).toHaveText('Go to Step 2: Verification');
+  });
 });

--- a/frontend/tests/pages/ContractsListPage.ts
+++ b/frontend/tests/pages/ContractsListPage.ts
@@ -15,6 +15,7 @@ export class ContractsListPage extends BasePage {
   readonly errorAlert: Locator;
   readonly noContractsAlert: Locator;
   readonly contractCards: Locator;
+  readonly goToStep2Button: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -28,6 +29,7 @@ export class ContractsListPage extends BasePage {
     this.errorAlert = page.locator('[role="alert"]').filter({ hasText: 'Error loading contracts' });
     this.noContractsAlert = page.locator('[role="alert"]').filter({ hasText: 'No contracts found' });
     this.contractCards = page.getByTestId('contract-card');
+    this.goToStep2Button = page.getByRole('button', { name: 'Go to Step 2: Verification' });
   }
 
   /**


### PR DESCRIPTION
Add 'Go to Step 2: Verification' button to the Contracts List page and an accompanying Playwright integration test to fulfill Linear issue PIA-26.

---
Linear Issue: [PIA-26](https://linear.app/piarsoftware/issue/PIA-26/add-button-to-go-to-step-two)

<a href="https://cursor.com/background-agent?bcId=bc-b84586ee-1d5a-4293-bb64-13a03997a9bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b84586ee-1d5a-4293-bb64-13a03997a9bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

