### PR TITLE
Validate module self-dependency in ai contract system

### DIFF
--- a/backend/src/contracts/contracts.service.ts
+++ b/backend/src/contracts/contracts.service.ts
@@ -255,6 +255,19 @@ export class ContractsService {
           }
         }
 
+        // Validation: Check for self-dependency (module depending on itself)
+        if (validationResult.success && contract.dependencies && contract.id) {
+          for (let i = 0; i < contract.dependencies.length; i++) {
+            const dep = contract.dependencies[i];
+            if (dep.module_id === contract.id) {
+              errors.push({
+                path: `dependencies.${i}.module_id`,
+                message: `Module "${contract.id}" cannot depend on itself. Self-dependencies are not allowed`,
+              });
+            }
+          }
+        }
+
         // Cross-contract validation: Check if referenced module IDs exist
         if (validationResult.success && contract.dependencies) {
           for (let i = 0; i < contract.dependencies.length; i++) {

--- a/backend/src/contracts/test-fixtures/invalid-self-dependency-with-others.yml
+++ b/backend/src/contracts/test-fixtures/invalid-self-dependency-with-others.yml
@@ -1,0 +1,22 @@
+id: complex-self-dependent
+type: service
+category: backend
+description: A module with multiple dependencies, including a self-dependency
+parts:
+  - id: method1
+    type: function
+  - id: method2
+    type: function
+dependencies:
+  - module_id: users-permissions
+    parts:
+      - part_id: id
+        type: string
+  - module_id: complex-self-dependent
+    parts:
+      - part_id: method1
+        type: function
+  - module_id: simple-service
+    parts:
+      - part_id: method2
+        type: function

--- a/backend/src/contracts/test-fixtures/invalid-self-dependency.yml
+++ b/backend/src/contracts/test-fixtures/invalid-self-dependency.yml
@@ -1,0 +1,14 @@
+id: self-dependent-module
+type: service
+category: backend
+description: A module that incorrectly depends on itself
+parts:
+  - id: function1
+    type: function
+  - id: function2
+    type: function
+dependencies:
+  - module_id: self-dependent-module
+    parts:
+      - part_id: function1
+        type: function

--- a/backend/src/contracts/test-fixtures/simple-service.yml
+++ b/backend/src/contracts/test-fixtures/simple-service.yml
@@ -1,0 +1,9 @@
+id: simple-service
+type: service
+category: backend
+description: A simple service without parts or dependencies
+parts:
+  - id: method1
+    type: function
+  - id: method2
+    type: function


### PR DESCRIPTION
Add validation to prevent modules from having self-dependencies, as required by PIA-40.

---
Linear Issue: [PIA-40](https://linear.app/piarsoftware/issue/PIA-40/add-verification-for-not-having-dependency-to-itself-by-module)

<a href="https://cursor.com/background-agent?bcId=bc-13e6a52f-d906-43c7-8179-8f41bfc41977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-13e6a52f-d906-43c7-8179-8f41bfc41977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

