### PR TITLE
Validate unique dependency parts in module

### DIFF
--- a/backend/src/contracts/test-fixtures/invalid-duplicate-parts-across-multiple-dependencies.yml
+++ b/backend/src/contracts/test-fixtures/invalid-duplicate-parts-across-multiple-dependencies.yml
@@ -1,0 +1,17 @@
+id: test-module-duplicates-across-dependencies
+type: controller
+category: api
+description: Test module with duplicate parts in different dependencies
+dependencies:
+  - module_id: users-permissions
+    parts:
+      - part_id: id
+        type: string
+      - part_id: id
+        type: string
+  - module_id: simple-service
+    parts:
+      - part_id: id
+        type: string
+      - part_id: id
+        type: string

--- a/backend/src/contracts/test-fixtures/invalid-duplicate-parts-in-dependency-multiple.yml
+++ b/backend/src/contracts/test-fixtures/invalid-duplicate-parts-in-dependency-multiple.yml
@@ -1,0 +1,15 @@
+id: test-module-multiple-duplicate-parts
+type: controller
+category: api
+description: Test module with multiple duplicate part_ids in single dependency
+dependencies:
+  - module_id: users-permissions
+    parts:
+      - part_id: id
+        type: string
+      - part_id: name
+        type: string
+      - part_id: id
+        type: string
+      - part_id: name
+        type: string

--- a/backend/src/contracts/test-fixtures/invalid-duplicate-parts-in-dependency-simple.yml
+++ b/backend/src/contracts/test-fixtures/invalid-duplicate-parts-in-dependency-simple.yml
@@ -1,0 +1,13 @@
+id: test-module-duplicate-parts
+type: controller
+category: api
+description: Test module with duplicate part_id in single dependency
+dependencies:
+  - module_id: users-permissions
+    parts:
+      - part_id: id
+        type: string
+      - part_id: name
+        type: string
+      - part_id: id
+        type: string

--- a/backend/src/contracts/test-fixtures/invalid-duplicate-parts-in-dependency-triple.yml
+++ b/backend/src/contracts/test-fixtures/invalid-duplicate-parts-in-dependency-triple.yml
@@ -1,0 +1,13 @@
+id: test-module-triple-duplicate-parts
+type: controller
+category: api
+description: Test module with triple occurrence of same part_id
+dependencies:
+  - module_id: users-permissions
+    parts:
+      - part_id: id
+        type: string
+      - part_id: id
+        type: string
+      - part_id: id
+        type: string


### PR DESCRIPTION
Add validation to ensure each `part_id` is unique within a module's dependency parts to prevent misconfigurations.

---
Linear Issue: [PIA-41](https://linear.app/piarsoftware/issue/PIA-41/add-verification-for-unique-each-dependency-parts-within-module)

<a href="https://cursor.com/background-agent?bcId=bc-aaa4df70-d1c0-489f-be92-632d75ac96dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aaa4df70-d1c0-489f-be92-632d75ac96dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

