### PR TITLE
Refactor validateContracts method

### DIFF
--- a/backend/src/contracts/contracts.service.ts
+++ b/backend/src/contracts/contracts.service.ts
@@ -81,6 +81,310 @@ export class ContractsService {
     }
   }
 
+  /**
+   * Parse contracts and collect metadata for validation
+   * First pass: Parse all contracts and collect their IDs and parts
+   */
+  private parseContractsAndCollectMetadata(
+    files: string[],
+  ): {
+    parsedContracts: Array<{
+      file: string;
+      fileName: string;
+      contract: any;
+    }>;
+    availableModuleIds: Set<string>;
+    moduleIdToFiles: Map<string, string[]>;
+    moduleParts: Map<string, Array<{ id: string; type: string }>>;
+    parseErrors: Array<{
+      filePath: string;
+      fileName: string;
+      valid: boolean;
+      errors?: Array<{ path: string; message: string }>;
+    }>;
+  } {
+    const parsedContracts: Array<{
+      file: string;
+      fileName: string;
+      contract: any;
+    }> = [];
+    const availableModuleIds = new Set<string>();
+    const moduleIdToFiles: Map<string, string[]> = new Map();
+    const moduleParts: Map<
+      string,
+      Array<{ id: string; type: string }>
+    > = new Map();
+    const parseErrors: Array<{
+      filePath: string;
+      fileName: string;
+      valid: boolean;
+      errors: Array<{ path: string; message: string }>;
+    }> = [];
+
+    for (const file of files) {
+      const fileName = path.basename(file);
+      try {
+        const fileContent = fs.readFileSync(file, "utf8");
+        const parsedContract = yaml.load(fileContent);
+
+        parsedContracts.push({
+          file,
+          fileName,
+          contract: parsedContract,
+        });
+
+        // Collect module IDs and parts for cross-contract validation
+        if (
+          parsedContract &&
+          typeof parsedContract === "object" &&
+          "id" in parsedContract &&
+          typeof parsedContract.id === "string"
+        ) {
+          availableModuleIds.add(parsedContract.id);
+
+          // Track which files use each module ID for duplicate detection
+          if (!moduleIdToFiles.has(parsedContract.id)) {
+            moduleIdToFiles.set(parsedContract.id, []);
+          }
+          moduleIdToFiles.get(parsedContract.id)!.push(fileName);
+
+          // Store module parts for type validation
+          if (
+            "parts" in parsedContract &&
+            parsedContract.parts &&
+            Array.isArray(parsedContract.parts)
+          ) {
+            moduleParts.set(parsedContract.id, parsedContract.parts);
+          }
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error";
+
+        parseErrors.push({
+          filePath: file,
+          fileName,
+          valid: false,
+          errors: [
+            {
+              path: "file",
+              message: `Failed to parse YAML: ${errorMessage}`,
+            },
+          ],
+        });
+        this.logger.error(`✗ Parse error in ${fileName}:`, errorMessage);
+      }
+    }
+
+    return {
+      parsedContracts,
+      availableModuleIds,
+      moduleIdToFiles,
+      moduleParts,
+      parseErrors,
+    };
+  }
+
+  /**
+   * Validate contract against schema
+   */
+  private validateSchema(contract: any): Array<{ path: string; message: string }> {
+    const validationResult = ContractSchema.safeParse(contract);
+    const errors: Array<{ path: string; message: string }> = [];
+
+    if (!validationResult.success) {
+      errors.push(
+        ...validationResult.error.issues.map((err) => ({
+          path: err.path.join(".") || "root",
+          message: err.message,
+        })),
+      );
+    }
+
+    return errors;
+  }
+
+  /**
+   * Validate for duplicate module IDs across different files
+   */
+  private validateDuplicateModuleIds(
+    contract: any,
+    fileName: string,
+    moduleIdToFiles: Map<string, string[]>,
+  ): Array<{ path: string; message: string }> {
+    const errors: Array<{ path: string; message: string }> = [];
+
+    if (contract.id && moduleIdToFiles.has(contract.id)) {
+      const filesWithSameId = moduleIdToFiles.get(contract.id)!;
+      if (filesWithSameId.length > 1) {
+        const otherFiles = filesWithSameId
+          .filter((f) => f !== fileName)
+          .join(", ");
+        errors.push({
+          path: "id",
+          message: `Duplicate module id "${contract.id}" found in files: ${otherFiles}`,
+        });
+      }
+    }
+
+    return errors;
+  }
+
+  /**
+   * Validate for duplicate module_id in dependencies array
+   */
+  private validateDuplicateDependencies(
+    contract: any,
+  ): Array<{ path: string; message: string }> {
+    const errors: Array<{ path: string; message: string }> = [];
+
+    if (contract.dependencies) {
+      const seenModuleIds = new Set<string>();
+      const duplicateModuleIds = new Set<string>();
+
+      for (let i = 0; i < contract.dependencies.length; i++) {
+        const dep = contract.dependencies[i];
+        if (seenModuleIds.has(dep.module_id)) {
+          duplicateModuleIds.add(dep.module_id);
+        } else {
+          seenModuleIds.add(dep.module_id);
+        }
+      }
+
+      // Add errors for all dependencies with duplicate module_ids
+      if (duplicateModuleIds.size > 0) {
+        for (let i = 0; i < contract.dependencies.length; i++) {
+          const dep = contract.dependencies[i];
+          if (duplicateModuleIds.has(dep.module_id)) {
+            errors.push({
+              path: `dependencies.${i}.module_id`,
+              message: `Duplicate dependency on module "${dep.module_id}". Each module should be listed only once in dependencies`,
+            });
+          }
+        }
+      }
+    }
+
+    return errors;
+  }
+
+  /**
+   * Validate for self-dependency (module depending on itself)
+   */
+  private validateSelfDependencies(
+    contract: any,
+  ): Array<{ path: string; message: string }> {
+    const errors: Array<{ path: string; message: string }> = [];
+
+    if (contract.dependencies && contract.id) {
+      for (let i = 0; i < contract.dependencies.length; i++) {
+        const dep = contract.dependencies[i];
+        if (dep.module_id === contract.id) {
+          errors.push({
+            path: `dependencies.${i}.module_id`,
+            message: `Module "${contract.id}" cannot depend on itself. Self-dependencies are not allowed`,
+          });
+        }
+      }
+    }
+
+    return errors;
+  }
+
+  /**
+   * Validate for duplicate part_id within each dependency's parts array
+   */
+  private validateDuplicatePartsInDependencies(
+    contract: any,
+  ): Array<{ path: string; message: string }> {
+    const errors: Array<{ path: string; message: string }> = [];
+
+    if (contract.dependencies) {
+      for (let i = 0; i < contract.dependencies.length; i++) {
+        const dep = contract.dependencies[i];
+        if (dep.parts && Array.isArray(dep.parts)) {
+          const seenPartIds = new Set<string>();
+          const duplicatePartIds = new Set<string>();
+
+          for (let j = 0; j < dep.parts.length; j++) {
+            const part = dep.parts[j];
+            if (seenPartIds.has(part.part_id)) {
+              duplicatePartIds.add(part.part_id);
+            } else {
+              seenPartIds.add(part.part_id);
+            }
+          }
+
+          // Add errors for all parts with duplicate part_ids
+          if (duplicatePartIds.size > 0) {
+            for (let j = 0; j < dep.parts.length; j++) {
+              const part = dep.parts[j];
+              if (duplicatePartIds.has(part.part_id)) {
+                errors.push({
+                  path: `dependencies.${i}.parts.${j}.part_id`,
+                  message: `Duplicate part_id "${part.part_id}" in dependency on module "${dep.module_id}". Each part should be referenced only once per dependency`,
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return errors;
+  }
+
+  /**
+   * Validate cross-contract references (module existence and part type matching)
+   */
+  private validateCrossContractReferences(
+    contract: any,
+    availableModuleIds: Set<string>,
+    moduleParts: Map<string, Array<{ id: string; type: string }>>,
+  ): Array<{ path: string; message: string }> {
+    const errors: Array<{ path: string; message: string }> = [];
+
+    if (contract.dependencies) {
+      for (let i = 0; i < contract.dependencies.length; i++) {
+        const dep = contract.dependencies[i];
+        if (!availableModuleIds.has(dep.module_id)) {
+          errors.push({
+            path: `dependencies.${i}.module_id`,
+            message: `Referenced module "${dep.module_id}" does not exist`,
+          });
+        } else {
+          // Validate dependency part types and existence
+          const referencedParts = moduleParts.get(dep.module_id);
+          if (dep.parts && Array.isArray(dep.parts)) {
+            for (let j = 0; j < dep.parts.length; j++) {
+              const depPart = dep.parts[j];
+              if (referencedParts) {
+                const matchingPart = referencedParts.find(
+                  (p) => p.id === depPart.part_id,
+                );
+                if (!matchingPart) {
+                  // Part ID doesn't exist in the referenced module
+                  errors.push({
+                    path: `dependencies.${i}.parts.${j}.part_id`,
+                    message: `Part "${depPart.part_id}" does not exist in module "${dep.module_id}"`,
+                  });
+                } else if (matchingPart.type !== depPart.type) {
+                  // Part exists but type doesn't match
+                  errors.push({
+                    path: `dependencies.${i}.parts.${j}.type`,
+                    message: `Part type mismatch for "${depPart.part_id}": expected "${matchingPart.type}" but got "${depPart.type}"`,
+                  });
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return errors;
+  }
+
   async validateContracts(): Promise<{
     valid: boolean;
     files: Array<{
@@ -120,224 +424,57 @@ export class ContractsService {
 
       this.logger.log(`Validating ${files.length} contract file(s)`);
 
-      const validationResults = [];
-      let allValid = true;
+      // Step 1: Parse all contracts and collect metadata
+      const {
+        parsedContracts,
+        availableModuleIds,
+        moduleIdToFiles,
+        moduleParts,
+        parseErrors,
+      } = this.parseContractsAndCollectMetadata(files);
 
-      // First pass: Parse all contracts and collect their IDs and parts
-      const parsedContracts: Array<{
-        file: string;
-        fileName: string;
-        contract: any;
-      }> = [];
-      const availableModuleIds = new Set<string>();
-      const moduleIdToFiles: Map<string, string[]> = new Map();
-      const moduleParts: Map<
-        string,
-        Array<{ id: string; type: string }>
-      > = new Map();
+      const validationResults = [...parseErrors];
+      let allValid = parseErrors.length === 0;
 
-      for (const file of files) {
-        const fileName = path.basename(file);
-        try {
-          const fileContent = fs.readFileSync(file, "utf8");
-          const parsedContract = yaml.load(fileContent);
-
-          parsedContracts.push({
-            file,
-            fileName,
-            contract: parsedContract,
-          });
-
-          // Collect module IDs and parts for cross-contract validation
-          if (
-            parsedContract &&
-            typeof parsedContract === "object" &&
-            "id" in parsedContract &&
-            typeof parsedContract.id === "string"
-          ) {
-            availableModuleIds.add(parsedContract.id);
-
-            // Track which files use each module ID for duplicate detection
-            if (!moduleIdToFiles.has(parsedContract.id)) {
-              moduleIdToFiles.set(parsedContract.id, []);
-            }
-            moduleIdToFiles.get(parsedContract.id)!.push(fileName);
-
-            // Store module parts for type validation
-            if (
-              "parts" in parsedContract &&
-              parsedContract.parts &&
-              Array.isArray(parsedContract.parts)
-            ) {
-              moduleParts.set(parsedContract.id, parsedContract.parts);
-            }
-          }
-        } catch (error) {
-          allValid = false;
-          const errorMessage =
-            error instanceof Error ? error.message : "Unknown error";
-
-          validationResults.push({
-            filePath: file,
-            fileName,
-            valid: false,
-            errors: [
-              {
-                path: "file",
-                message: `Failed to parse YAML: ${errorMessage}`,
-              },
-            ],
-          });
-          this.logger.error(`✗ Parse error in ${fileName}:`, errorMessage);
-        }
-      }
-
-      // Second pass: Validate each contract with cross-contract validation
+      // Step 2: Validate each contract with all validation rules
       for (const { file, fileName, contract } of parsedContracts) {
-        // Validate the parsed contract against the schema
-        const validationResult = ContractSchema.safeParse(contract);
-
         const errors: Array<{ path: string; message: string }> = [];
 
-        // Add schema validation errors
-        if (!validationResult.success) {
+        // Validate the parsed contract against the schema
+        const schemaValidation = ContractSchema.safeParse(contract);
+        const isSchemaValid = schemaValidation.success;
+
+        // Step 2a: Schema validation
+        errors.push(...this.validateSchema(contract));
+
+        // Step 2b-2f: Run additional validations only if schema is valid
+        if (isSchemaValid) {
+          // Step 2b: Check for duplicate module IDs
           errors.push(
-            ...validationResult.error.issues.map((err) => ({
-              path: err.path.join(".") || "root",
-              message: err.message,
-            })),
+            ...this.validateDuplicateModuleIds(
+              contract,
+              fileName,
+              moduleIdToFiles,
+            ),
           );
-        }
 
-        // Cross-contract validation: Check for duplicate module IDs
-        if (
-          validationResult.success &&
-          contract.id &&
-          moduleIdToFiles.has(contract.id)
-        ) {
-          const filesWithSameId = moduleIdToFiles.get(contract.id)!;
-          if (filesWithSameId.length > 1) {
-            const otherFiles = filesWithSameId
-              .filter((f) => f !== fileName)
-              .join(", ");
-            errors.push({
-              path: "id",
-              message: `Duplicate module id "${contract.id}" found in files: ${otherFiles}`,
-            });
-          }
-        }
+          // Step 2c: Check for duplicate dependencies
+          errors.push(...this.validateDuplicateDependencies(contract));
 
-        // Validation: Check for duplicate module_id in dependencies array
-        if (validationResult.success && contract.dependencies) {
-          const seenModuleIds = new Set<string>();
-          const duplicateModuleIds = new Set<string>();
-          
-          for (let i = 0; i < contract.dependencies.length; i++) {
-            const dep = contract.dependencies[i];
-            if (seenModuleIds.has(dep.module_id)) {
-              duplicateModuleIds.add(dep.module_id);
-            } else {
-              seenModuleIds.add(dep.module_id);
-            }
-          }
-          
-          // Add errors for all dependencies with duplicate module_ids
-          if (duplicateModuleIds.size > 0) {
-            for (let i = 0; i < contract.dependencies.length; i++) {
-              const dep = contract.dependencies[i];
-              if (duplicateModuleIds.has(dep.module_id)) {
-                errors.push({
-                  path: `dependencies.${i}.module_id`,
-                  message: `Duplicate dependency on module "${dep.module_id}". Each module should be listed only once in dependencies`,
-                });
-              }
-            }
-          }
-        }
+          // Step 2d: Check for self-dependencies
+          errors.push(...this.validateSelfDependencies(contract));
 
-        // Validation: Check for self-dependency (module depending on itself)
-        if (validationResult.success && contract.dependencies && contract.id) {
-          for (let i = 0; i < contract.dependencies.length; i++) {
-            const dep = contract.dependencies[i];
-            if (dep.module_id === contract.id) {
-              errors.push({
-                path: `dependencies.${i}.module_id`,
-                message: `Module "${contract.id}" cannot depend on itself. Self-dependencies are not allowed`,
-              });
-            }
-          }
-        }
+          // Step 2e: Check for duplicate parts in dependencies
+          errors.push(...this.validateDuplicatePartsInDependencies(contract));
 
-        // Validation: Check for duplicate part_id within each dependency's parts array
-        if (validationResult.success && contract.dependencies) {
-          for (let i = 0; i < contract.dependencies.length; i++) {
-            const dep = contract.dependencies[i];
-            if (dep.parts && Array.isArray(dep.parts)) {
-              const seenPartIds = new Set<string>();
-              const duplicatePartIds = new Set<string>();
-              
-              for (let j = 0; j < dep.parts.length; j++) {
-                const part = dep.parts[j];
-                if (seenPartIds.has(part.part_id)) {
-                  duplicatePartIds.add(part.part_id);
-                } else {
-                  seenPartIds.add(part.part_id);
-                }
-              }
-              
-              // Add errors for all parts with duplicate part_ids
-              if (duplicatePartIds.size > 0) {
-                for (let j = 0; j < dep.parts.length; j++) {
-                  const part = dep.parts[j];
-                  if (duplicatePartIds.has(part.part_id)) {
-                    errors.push({
-                      path: `dependencies.${i}.parts.${j}.part_id`,
-                      message: `Duplicate part_id "${part.part_id}" in dependency on module "${dep.module_id}". Each part should be referenced only once per dependency`,
-                    });
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        // Cross-contract validation: Check if referenced module IDs exist
-        if (validationResult.success && contract.dependencies) {
-          for (let i = 0; i < contract.dependencies.length; i++) {
-            const dep = contract.dependencies[i];
-            if (!availableModuleIds.has(dep.module_id)) {
-              errors.push({
-                path: `dependencies.${i}.module_id`,
-                message: `Referenced module "${dep.module_id}" does not exist`,
-              });
-            } else {
-              // Validate dependency part types and existence
-              const referencedParts = moduleParts.get(dep.module_id);
-              if (dep.parts && Array.isArray(dep.parts)) {
-                for (let j = 0; j < dep.parts.length; j++) {
-                  const depPart = dep.parts[j];
-                  if (referencedParts) {
-                    const matchingPart = referencedParts.find(
-                      (p) => p.id === depPart.part_id,
-                    );
-                    if (!matchingPart) {
-                      // Part ID doesn't exist in the referenced module
-                      errors.push({
-                        path: `dependencies.${i}.parts.${j}.part_id`,
-                        message: `Part "${depPart.part_id}" does not exist in module "${dep.module_id}"`,
-                      });
-                    } else if (matchingPart.type !== depPart.type) {
-                      // Part exists but type doesn't match
-                      errors.push({
-                        path: `dependencies.${i}.parts.${j}.type`,
-                        message: `Part type mismatch for "${depPart.part_id}": expected "${matchingPart.type}" but got "${depPart.type}"`,
-                      });
-                    }
-                  }
-                }
-              }
-            }
-          }
+          // Step 2f: Check cross-contract references
+          errors.push(
+            ...this.validateCrossContractReferences(
+              contract,
+              availableModuleIds,
+              moduleParts,
+            ),
+          );
         }
 
         // Determine if this file is valid


### PR DESCRIPTION
Refactor `validateContracts` method in `contracts.service.ts` to split its long body into separate, focused validation functions.

The original `validateContracts` method was nearly 300 lines long. This PR extracts distinct validation logic into 7 new private methods, making the main `validateContracts` method an orchestrator that invokes these steps sequentially. This improves readability, maintainability, and adherence to the Single Responsibility Principle.

---
Linear Issue: [PIA-42](https://linear.app/piarsoftware/issue/PIA-42/refactor-validatecontracts-in-contracts-service)

<a href="https://cursor.com/background-agent?bcId=bc-a65e7dee-04a3-48f5-87b5-f53da62641d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a65e7dee-04a3-48f5-87b5-f53da62641d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

