### PR TITLE
Add module relations endpoint and tests

### DIFF
--- a/backend/src/contracts/dto/module-relations-response.dto.ts
+++ b/backend/src/contracts/dto/module-relations-response.dto.ts
@@ -1,0 +1,76 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+/**
+ * DTO for a part used in a dependency
+ */
+export class DependencyPartDto {
+  @ApiProperty({
+    description: "Part ID",
+    example: "getUserById",
+  })
+  part_id: string;
+
+  @ApiProperty({
+    description: "Part type",
+    example: "function",
+  })
+  type: string;
+}
+
+/**
+ * DTO for outgoing dependency (module that this module depends on)
+ */
+export class OutgoingDependencyDto {
+  @ApiProperty({
+    description: "Module ID that this module depends on",
+    example: "users-service",
+  })
+  module_id: string;
+
+  @ApiProperty({
+    description: "Parts from the dependency module that this module uses",
+    type: [DependencyPartDto],
+  })
+  parts: DependencyPartDto[];
+}
+
+/**
+ * DTO for incoming dependency (module that depends on this module)
+ */
+export class IncomingDependencyDto {
+  @ApiProperty({
+    description: "Module ID that depends on this module",
+    example: "users-controller",
+  })
+  module_id: string;
+
+  @ApiProperty({
+    description: "Parts from this module that the dependent module uses",
+    type: [DependencyPartDto],
+  })
+  parts: DependencyPartDto[];
+}
+
+/**
+ * DTO for module relations response
+ */
+export class ModuleRelationsResponseDto {
+  @ApiProperty({
+    description: "The module ID being queried",
+    example: "users-service",
+  })
+  module_id: string;
+
+  @ApiProperty({
+    description: "Outgoing dependencies - modules that this module depends on",
+    type: [OutgoingDependencyDto],
+  })
+  outgoing_dependencies: OutgoingDependencyDto[];
+
+  @ApiProperty({
+    description:
+      "Incoming dependencies - modules that depend on this module and which parts they use",
+    type: [IncomingDependencyDto],
+  })
+  incoming_dependencies: IncomingDependencyDto[];
+}


### PR DESCRIPTION
Adds `GET /contracts/:module_id/relations` endpoint to return a module's incoming and outgoing dependencies, including the specific parts used, as required by Linear issue PIA-43.

---
Linear Issue: [PIA-43](https://linear.app/piarsoftware/issue/PIA-43/add-endpoint-returning-relations-for-module)

<a href="https://cursor.com/background-agent?bcId=bc-8c022e97-3a58-4bcc-ad80-2586f648a9de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c022e97-3a58-4bcc-ad80-2586f648a9de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds GET /contracts/:module_id/relations to return a module’s outgoing/incoming dependencies (with parts), backed by Neo4j queries and covered by tests.
> 
> - **API (contracts controller)**
>   - `GET /contracts/:module_id/relations`: returns a module’s `outgoing_dependencies` and `incoming_dependencies` with `parts` used.
>   - Swagger docs: adds `@ApiParam` for `module_id` and 200/404 responses.
>   - Maps "not found" service errors to `404 NotFoundException`.
> - **Service (contracts.service.ts)**
>   - Implements `getModuleRelations(moduleId)`: verifies module existence, queries Neo4j for `MODULE_DEPENDENCY` edges (both directions), parses `r.parts` JSON, and returns structured relations.
> - **DTOs**
>   - Adds `ModuleRelationsResponseDto`, `OutgoingDependencyDto`, `IncomingDependencyDto`, `DependencyPartDto`.
> - **Tests**
>   - Controller and service specs covering success paths, no deps, only incoming/outgoing, multiple parts, parameter propagation, and error cases (module not found, Neo4j/query failures, session close).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7aa1c93a867ad77a9ee6c60f235c23c45c5ef80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->