### PR TITLE
Fix neo4j module duplication bug

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,7 +2,6 @@ import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { AppController } from "./app.controller";
 import { AppService } from "./app.service";
-import { Neo4jModule } from "./neo4j/neo4j.module";
 import { ContractsModule } from "./contracts/contracts.module";
 
 @Module({
@@ -10,7 +9,6 @@ import { ContractsModule } from "./contracts/contracts.module";
     ConfigModule.forRoot({
       isGlobal: true,
     }),
-    Neo4jModule,
     ContractsModule,
   ],
   controllers: [AppController],

--- a/backend/src/contracts/contracts.service.spec.ts
+++ b/backend/src/contracts/contracts.service.spec.ts
@@ -1127,18 +1127,18 @@ describe("ContractsService", () => {
 
       await service.applyContractsToNeo4j(contractFiles);
 
-      // Verify constraint creation is called first
-      expect(mockSession.run.mock.calls[0][0]).toContain(
+      // Verify database clearing happens FIRST (before constraint creation)
+      expect(mockSession.run.mock.calls[0][0]).toContain("MATCH (n) DETACH DELETE n");
+
+      // Verify constraint creation is called SECOND (after clearing removes duplicates)
+      expect(mockSession.run.mock.calls[1][0]).toContain(
         "CREATE CONSTRAINT module_id_unique",
       );
 
-      // Verify executeWrite is called to run operations in a transaction
+      // Verify executeWrite is called to run data operations in a transaction
       expect(mockSession.executeWrite).toHaveBeenCalled();
 
-      // Verify database clearing happens inside transaction (second operation)
-      expect(mockSession.run.mock.calls[1][0]).toContain("MATCH (n) DETACH DELETE n");
-
-      // Verify module creation happens AFTER clearing (third operation)
+      // Verify module creation happens inside transaction (third operation)
       expect(mockSession.run.mock.calls[2][0]).toContain(
         "MERGE (m:Module {module_id: $module_id})",
       );

--- a/backend/src/neo4j/neo4j.module.ts
+++ b/backend/src/neo4j/neo4j.module.ts
@@ -1,6 +1,7 @@
-import { Module } from "@nestjs/common";
+import { Module, Global } from "@nestjs/common";
 import { Neo4jService } from "./neo4j.service";
 
+@Global()
 @Module({
   providers: [Neo4jService],
   exports: [Neo4jService],


### PR DESCRIPTION
Make `Neo4jModule` global and remove its duplicate import to prevent module duplication in Neo4j.

The `Neo4jModule` was imported twice, leading to multiple `Neo4jService` instances and race conditions that created duplicate module nodes. Marking the module as global ensures a single, shared instance, resolving this issue.

---
Linear Issue: [PIA-46](https://linear.app/piarsoftware/issue/PIA-46/modules-duplicated-in-neo4j)

<a href="https://cursor.com/background-agent?bcId=bc-e35e7065-016e-4c37-8a7e-9ccbc3c0d696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e35e7065-016e-4c37-8a7e-9ccbc3c0d696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks `Neo4jModule` as global and removes its duplicate import; refactors contract application to clear DB, ensure unique constraint, and perform atomic writes in a transaction with updated relationship semantics.
> 
> - **Backend**
>   - **Neo4j**: Mark `Neo4jModule` as `@Global()` and remove duplicate import from `backend/src/app.module.ts`.
>   - **ContractsService (`applyContractsToNeo4j`)**:
>     - Clear database first (`MATCH (n) DETACH DELETE n`), then ensure uniqueness constraint (`CREATE CONSTRAINT module_id_unique IF NOT EXISTS`).
>     - Execute data writes via `session.executeWrite` using transactional `tx.run` for atomicity.
>     - Update `MODULE_DEPENDENCY` to `MERGE (m)-[r:MODULE_DEPENDENCY]->(d)` and store `r.parts` as JSON; remove redundant relationship properties.
>     - Return processed counts from the transaction and adjust logging.
> - **Tests**
>   - Update mocks to support `executeWrite` and transactional `run`.
>   - Assert operation order (clear → constraint → transactional writes), relationship pattern changes, and constraint creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 932c3e0249f647d873aad33aee4f6c4dbed17683. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->