### PR TITLE
Search by description endpoint

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -124,6 +124,93 @@
           "contracts"
         ]
       }
+    },
+    "/api/contracts/{module_id}/relations": {
+      "get": {
+        "operationId": "ContractsController_getModuleRelations",
+        "summary": "Get relations for a specific module",
+        "description": "Returns outgoing dependencies (modules this module depends on) and incoming dependencies (modules that depend on this module) with the parts they use",
+        "parameters": [
+          {
+            "name": "module_id",
+            "required": true,
+            "in": "path",
+            "description": "The module ID to get relations for",
+            "schema": {
+              "example": "users-service",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns module relations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModuleRelationsResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Module not found"
+          }
+        },
+        "tags": [
+          "contracts"
+        ]
+      }
+    },
+    "/api/contracts/search": {
+      "get": {
+        "operationId": "ContractsController_searchByDescription",
+        "summary": "Search modules by description using semantic similarity",
+        "description": "Searches for modules using embedding-based semantic similarity. The query description is embedded and compared against stored module embeddings to find the most similar modules.",
+        "parameters": [
+          {
+            "name": "query",
+            "required": true,
+            "in": "query",
+            "description": "The search query text to find similar modules",
+            "schema": {
+              "example": "user authentication service",
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Maximum number of results to return (default: 10)",
+            "schema": {
+              "example": 10,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns search results ordered by similarity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchByDescriptionResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid search query (empty or missing)"
+          },
+          "500": {
+            "description": "Failed to perform search (embedding service not ready or Neo4j error)"
+          }
+        },
+        "tags": [
+          "contracts"
+        ]
+      }
     }
   },
   "info": {
@@ -152,12 +239,18 @@
           "content": {
             "type": "object",
             "description": "The parsed contract content"
+          },
+          "fileHash": {
+            "type": "string",
+            "description": "SHA256 hash of the contract file content",
+            "example": "a3d2f1e8b9c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1"
           }
         },
         "required": [
           "fileName",
           "filePath",
-          "content"
+          "content",
+          "fileHash"
         ]
       },
       "ValidationErrorDto": {
@@ -232,37 +325,6 @@
           "files"
         ]
       },
-      "ApplyResponseDto": {
-        "type": "object",
-        "properties": {
-          "success": {
-            "type": "boolean",
-            "description": "Whether the operation was successful",
-            "example": true
-          },
-          "modulesProcessed": {
-            "type": "number",
-            "description": "Number of modules processed",
-            "example": 5
-          },
-          "partsProcessed": {
-            "type": "number",
-            "description": "Number of parts processed",
-            "example": 12
-          },
-          "message": {
-            "type": "string",
-            "description": "Success or error message",
-            "example": "Successfully applied 5 modules and 12 parts to Neo4j"
-          }
-        },
-        "required": [
-          "success",
-          "modulesProcessed",
-          "partsProcessed",
-          "message"
-        ]
-      },
       "ModifiedContractDto": {
         "type": "object",
         "properties": {
@@ -296,7 +358,11 @@
             "type": "string",
             "description": "The status of the contract: 'modified', 'added', or 'removed'",
             "example": "modified",
-            "enum": ["modified", "added", "removed"]
+            "enum": [
+              "modified",
+              "added",
+              "removed"
+            ]
           }
         },
         "required": [
@@ -336,8 +402,8 @@
             "example": 0
           },
           "changes": {
-            "type": "array",
             "description": "List of contracts that have been modified, added, or removed",
+            "type": "array",
             "items": {
               "$ref": "#/components/schemas/ModifiedContractDto"
             }
@@ -350,6 +416,191 @@
           "addedCount",
           "removedCount",
           "changes"
+        ]
+      },
+      "ApplyResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Whether the operation was successful",
+            "example": true
+          },
+          "modulesProcessed": {
+            "type": "number",
+            "description": "Number of modules processed",
+            "example": 5
+          },
+          "partsProcessed": {
+            "type": "number",
+            "description": "Number of parts processed",
+            "example": 12
+          },
+          "message": {
+            "type": "string",
+            "description": "Success or error message",
+            "example": "Successfully applied 5 modules and 12 parts to Neo4j"
+          }
+        },
+        "required": [
+          "success",
+          "modulesProcessed",
+          "partsProcessed",
+          "message"
+        ]
+      },
+      "DependencyPartDto": {
+        "type": "object",
+        "properties": {
+          "part_id": {
+            "type": "string",
+            "description": "Part ID",
+            "example": "getUserById"
+          },
+          "type": {
+            "type": "string",
+            "description": "Part type",
+            "example": "function"
+          }
+        },
+        "required": [
+          "part_id",
+          "type"
+        ]
+      },
+      "OutgoingDependencyDto": {
+        "type": "object",
+        "properties": {
+          "module_id": {
+            "type": "string",
+            "description": "Module ID that this module depends on",
+            "example": "users-service"
+          },
+          "parts": {
+            "description": "Parts from the dependency module that this module uses",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DependencyPartDto"
+            }
+          }
+        },
+        "required": [
+          "module_id",
+          "parts"
+        ]
+      },
+      "IncomingDependencyDto": {
+        "type": "object",
+        "properties": {
+          "module_id": {
+            "type": "string",
+            "description": "Module ID that depends on this module",
+            "example": "users-controller"
+          },
+          "parts": {
+            "description": "Parts from this module that the dependent module uses",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DependencyPartDto"
+            }
+          }
+        },
+        "required": [
+          "module_id",
+          "parts"
+        ]
+      },
+      "ModuleRelationsResponseDto": {
+        "type": "object",
+        "properties": {
+          "module_id": {
+            "type": "string",
+            "description": "The module ID being queried",
+            "example": "users-service"
+          },
+          "outgoing_dependencies": {
+            "description": "Outgoing dependencies - modules that this module depends on",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OutgoingDependencyDto"
+            }
+          },
+          "incoming_dependencies": {
+            "description": "Incoming dependencies - modules that depend on this module and which parts they use",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncomingDependencyDto"
+            }
+          }
+        },
+        "required": [
+          "module_id",
+          "outgoing_dependencies",
+          "incoming_dependencies"
+        ]
+      },
+      "ModuleSearchResultDto": {
+        "type": "object",
+        "properties": {
+          "module_id": {
+            "type": "string",
+            "description": "The module ID",
+            "example": "users-service"
+          },
+          "type": {
+            "type": "string",
+            "description": "The module type",
+            "example": "service"
+          },
+          "description": {
+            "type": "string",
+            "description": "The module description",
+            "example": "Service for managing user data and authentication"
+          },
+          "category": {
+            "type": "string",
+            "description": "The module category",
+            "example": "backend"
+          },
+          "similarity": {
+            "type": "number",
+            "description": "Similarity score (0-1, where 1 is most similar)",
+            "example": 0.85
+          }
+        },
+        "required": [
+          "module_id",
+          "type",
+          "description",
+          "category",
+          "similarity"
+        ]
+      },
+      "SearchByDescriptionResponseDto": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "The search query that was used",
+            "example": "authentication service"
+          },
+          "resultsCount": {
+            "type": "number",
+            "description": "Number of results returned",
+            "example": 5
+          },
+          "results": {
+            "description": "Array of module search results ordered by similarity (highest first)",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModuleSearchResultDto"
+            }
+          }
+        },
+        "required": [
+          "query",
+          "resultsCount",
+          "results"
         ]
       }
     }

--- a/backend/src/contracts/contracts.service.spec.ts
+++ b/backend/src/contracts/contracts.service.spec.ts
@@ -5,6 +5,7 @@ import { Neo4jService } from "../neo4j/neo4j.service";
 import { EmbeddingService } from "./embedding.service";
 import { Contract } from "./contract.schema";
 import { ContractFileDto } from "./dto/contract-response.dto";
+import { int as neo4jInt } from "neo4j-driver";
 import * as path from "path";
 import * as crypto from "crypto";
 
@@ -2799,7 +2800,7 @@ describe("ContractsService", () => {
         expect.stringContaining("MATCH (m:Module)"),
         expect.objectContaining({
           queryEmbedding: mockEmbedding,
-          limit: 10,
+          limit: neo4jInt(10),
         }),
       );
 
@@ -2821,7 +2822,7 @@ describe("ContractsService", () => {
       expect(mockSession.run).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          limit: customLimit,
+          limit: neo4jInt(customLimit),
         }),
       );
     });

--- a/backend/src/contracts/contracts.service.ts
+++ b/backend/src/contracts/contracts.service.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 import * as crypto from "crypto";
 import * as yaml from "js-yaml";
 import { glob } from "glob";
+import { int as neo4jInt } from "neo4j-driver";
 import { ContractSchema, Contract } from "./contract.schema";
 import { ContractFileDto } from "./dto/contract-response.dto";
 import { Neo4jService } from "../neo4j/neo4j.service";
@@ -965,7 +966,7 @@ export class ContractsService implements OnModuleInit {
         `,
         {
           queryEmbedding,
-          limit: limit,
+          limit: neo4jInt(limit),
         },
       );
 

--- a/backend/src/contracts/contracts.service.ts
+++ b/backend/src/contracts/contracts.service.ts
@@ -19,6 +19,10 @@ import {
   IncomingDependencyDto,
   DependencyPartDto,
 } from "./dto/module-relations-response.dto";
+import {
+  SearchByDescriptionResponseDto,
+  ModuleSearchResultDto,
+} from "./dto/search-by-description-response.dto";
 
 @Injectable()
 export class ContractsService implements OnModuleInit {
@@ -900,6 +904,97 @@ export class ContractsService implements OnModuleInit {
         error.message,
       );
       throw error;
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * Search for modules by description using embedding similarity
+   * @param query The search query text
+   * @param limit Maximum number of results to return (default: 10)
+   * @returns Object with search results ordered by similarity
+   */
+  async searchByDescription(
+    query: string,
+    limit: number = 10,
+  ): Promise<SearchByDescriptionResponseDto> {
+    // Validate input
+    if (!query || query.trim().length === 0) {
+      throw new Error("Search query cannot be empty");
+    }
+
+    // Check if embedding service is ready
+    if (!this.embeddingService.isReady()) {
+      throw new Error(
+        "Embedding service is not ready. Cannot perform semantic search.",
+      );
+    }
+
+    const session = this.neo4jService.getSession();
+
+    try {
+      // Generate embedding for the search query
+      this.logger.log(`Generating embedding for search query: "${query}"`);
+      const queryEmbedding = await this.embeddingService.generateEmbedding(query);
+      this.logger.log(
+        `Generated query embedding with ${queryEmbedding.length} dimensions`,
+      );
+
+      // Perform vector similarity search in Neo4j
+      // Neo4j doesn't have built-in cosine similarity for lists, so we'll calculate it manually
+      // We use the formula: cosine_similarity = dot_product / (norm_a * norm_b)
+      // Since our embeddings are already normalized (normalize: true in embedding generation),
+      // we can use dot product directly as cosine similarity
+      const result = await session.run(
+        `
+        MATCH (m:Module)
+        WHERE m.embedding IS NOT NULL
+        WITH m, 
+             reduce(dot = 0.0, i IN range(0, size(m.embedding)-1) | 
+               dot + m.embedding[i] * $queryEmbedding[i]
+             ) AS similarity
+        WHERE similarity > 0
+        RETURN m.module_id AS module_id,
+               m.type AS type,
+               m.description AS description,
+               m.category AS category,
+               similarity
+        ORDER BY similarity DESC
+        LIMIT $limit
+        `,
+        {
+          queryEmbedding,
+          limit: limit,
+        },
+      );
+
+      // Map the results to DTOs
+      const results: ModuleSearchResultDto[] = result.records.map((record) => ({
+        module_id: record.get("module_id"),
+        type: record.get("type"),
+        description: record.get("description"),
+        category: record.get("category"),
+        similarity: record.get("similarity"),
+      }));
+
+      this.logger.log(
+        `Found ${results.length} modules matching query "${query}"`,
+      );
+
+      return {
+        query,
+        resultsCount: results.length,
+        results,
+      };
+    } catch (error) {
+      this.logger.error(
+        `Error searching modules by description for query "${query}":`,
+        error.message,
+      );
+      throw new Error(
+        `Failed to search modules by description: ${error.message}`,
+      );
     } finally {
       await session.close();
     }

--- a/backend/src/contracts/dto/search-by-description-response.dto.ts
+++ b/backend/src/contracts/dto/search-by-description-response.dto.ts
@@ -1,0 +1,59 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+/**
+ * DTO for a single module search result
+ */
+export class ModuleSearchResultDto {
+  @ApiProperty({
+    description: "The module ID",
+    example: "users-service",
+  })
+  module_id: string;
+
+  @ApiProperty({
+    description: "The module type",
+    example: "service",
+  })
+  type: string;
+
+  @ApiProperty({
+    description: "The module description",
+    example: "Service for managing user data and authentication",
+  })
+  description: string;
+
+  @ApiProperty({
+    description: "The module category",
+    example: "backend",
+  })
+  category: string;
+
+  @ApiProperty({
+    description: "Similarity score (0-1, where 1 is most similar)",
+    example: 0.85,
+  })
+  similarity: number;
+}
+
+/**
+ * DTO for search by description response
+ */
+export class SearchByDescriptionResponseDto {
+  @ApiProperty({
+    description: "The search query that was used",
+    example: "authentication service",
+  })
+  query: string;
+
+  @ApiProperty({
+    description: "Number of results returned",
+    example: 5,
+  })
+  resultsCount: number;
+
+  @ApiProperty({
+    description: "Array of module search results ordered by similarity (highest first)",
+    type: [ModuleSearchResultDto],
+  })
+  results: ModuleSearchResultDto[];
+}

--- a/contracts/post-component.yml
+++ b/contracts/post-component.yml
@@ -1,0 +1,21 @@
+id: post-component
+type: ui
+description: Post component for the frontend
+category: component
+parts:
+  - id: id
+    type: string
+  - id: name
+    type: string
+  - id: description
+    type: string
+  - id: image
+    type: string
+  - id: likes
+    type: number
+  - id: comments
+    type: array
+    items:
+      type: object
+      properties:
+        id:


### PR DESCRIPTION
Add an endpoint to search modules by description using semantic similarity to fulfill issue PIA-48.

---
Linear Issue: [PIA-48](https://linear.app/piarsoftware/issue/PIA-48/endpoint-to-search-by-description)

<a href="https://cursor.com/background-agent?bcId=bc-0cd06071-585c-44a0-b279-e30eae7b006b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0cd06071-585c-44a0-b279-e30eae7b006b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements semantic module search and documents it.
> 
> - Adds `GET /api/contracts/search` with `query` and optional `limit` using embedding-based similarity in Neo4j; validates inputs and maps service errors (embedding not ready, Neo4j) to HTTP responses
> - Introduces `SearchByDescriptionResponseDto` and `ModuleSearchResultDto`; updates OpenAPI (new path, schemas) and documents `contracts/{module_id}/relations`
> - Updates `ContractFileDto` to require `fileHash`
> - Extensive unit tests for controller/service covering search results, ordering, limits, and error paths
> - Adds sample contract `contracts/post-component.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3345ed67a4f9dc490b481348756ecf5763b408d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->