### PR TITLE
Contract search data consistency

### DIFF
--- a/backend/src/contracts/contracts.controller.spec.ts
+++ b/backend/src/contracts/contracts.controller.spec.ts
@@ -1212,24 +1212,39 @@ describe("ContractsController", () => {
       resultsCount: 3,
       results: [
         {
-          module_id: "auth-service",
-          type: "service",
-          description: "Authentication service for user login",
-          category: "backend",
+          fileName: "auth-service.yml",
+          filePath: "/contracts/auth-service.yml",
+          fileHash: "hash123",
+          content: {
+            id: "auth-service",
+            type: "service",
+            description: "Authentication service for user login",
+            category: "backend",
+          },
           similarity: 0.92,
         },
         {
-          module_id: "users-service",
-          type: "service",
-          description: "User management service",
-          category: "backend",
+          fileName: "users-service.yml",
+          filePath: "/contracts/users-service.yml",
+          fileHash: "hash456",
+          content: {
+            id: "users-service",
+            type: "service",
+            description: "User management service",
+            category: "backend",
+          },
           similarity: 0.78,
         },
         {
-          module_id: "login-controller",
-          type: "controller",
-          description: "User login endpoint",
-          category: "api",
+          fileName: "login-controller.yml",
+          filePath: "/contracts/login-controller.yml",
+          fileHash: "hash789",
+          content: {
+            id: "login-controller",
+            type: "controller",
+            description: "User login endpoint",
+            category: "api",
+          },
           similarity: 0.65,
         },
       ],
@@ -1311,10 +1326,14 @@ describe("ContractsController", () => {
       const result = await controller.searchByDescription("user authentication");
 
       result.results.forEach((item) => {
-        expect(item).toHaveProperty("module_id");
-        expect(item).toHaveProperty("type");
-        expect(item).toHaveProperty("description");
-        expect(item).toHaveProperty("category");
+        expect(item).toHaveProperty("fileName");
+        expect(item).toHaveProperty("filePath");
+        expect(item).toHaveProperty("fileHash");
+        expect(item).toHaveProperty("content");
+        expect(item.content).toHaveProperty("id");
+        expect(item.content).toHaveProperty("type");
+        expect(item.content).toHaveProperty("description");
+        expect(item.content).toHaveProperty("category");
         expect(item).toHaveProperty("similarity");
         expect(typeof item.similarity).toBe("number");
         expect(item.similarity).toBeGreaterThan(0);
@@ -1469,10 +1488,15 @@ describe("ContractsController", () => {
         results: Array(10)
           .fill(null)
           .map((_, i) => ({
-            module_id: `service-${i}`,
-            type: "service",
-            description: `Service number ${i}`,
-            category: "backend",
+            fileName: `service-${i}.yml`,
+            filePath: `/contracts/service-${i}.yml`,
+            fileHash: `hash${i}`,
+            content: {
+              id: `service-${i}`,
+              type: "service",
+              description: `Service number ${i}`,
+              category: "backend",
+            },
             similarity: 0.9 - i * 0.05,
           })),
       };

--- a/backend/src/contracts/contracts.service.spec.ts
+++ b/backend/src/contracts/contracts.service.spec.ts
@@ -2754,9 +2754,6 @@ describe("ContractsService", () => {
           get: (field: string) => {
             const data = {
               module_id: "auth-service",
-              type: "service",
-              description: "Authentication service for users",
-              category: "backend",
               similarity: 0.92,
             };
             return data[field];
@@ -2766,12 +2763,34 @@ describe("ContractsService", () => {
           get: (field: string) => {
             const data = {
               module_id: "users-service",
-              type: "service",
-              description: "User management service",
-              category: "backend",
               similarity: 0.78,
             };
             return data[field];
+          },
+        },
+      ];
+
+      const mockContracts = [
+        {
+          fileName: "auth-service.yml",
+          filePath: "/contracts/auth-service.yml",
+          fileHash: "hash123",
+          content: {
+            id: "auth-service",
+            type: "service",
+            description: "Authentication service for users",
+            category: "backend",
+          },
+        },
+        {
+          fileName: "users-service.yml",
+          filePath: "/contracts/users-service.yml",
+          fileHash: "hash456",
+          content: {
+            id: "users-service",
+            type: "service",
+            description: "User management service",
+            category: "backend",
           },
         },
       ];
@@ -2780,6 +2799,7 @@ describe("ContractsService", () => {
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
       mockSession.run.mockResolvedValue({ records: mockResults });
+      jest.spyOn(service, "getAllContracts").mockResolvedValue(mockContracts);
 
       const result = await service.searchByDescription(query, 10);
 
@@ -2787,9 +2807,11 @@ describe("ContractsService", () => {
       expect(result.query).toBe(query);
       expect(result.resultsCount).toBe(2);
       expect(result.results).toHaveLength(2);
-      expect(result.results[0].module_id).toBe("auth-service");
+      expect(result.results[0].fileName).toBe("auth-service.yml");
+      expect(result.results[0].content.id).toBe("auth-service");
       expect(result.results[0].similarity).toBe(0.92);
-      expect(result.results[1].module_id).toBe("users-service");
+      expect(result.results[1].fileName).toBe("users-service.yml");
+      expect(result.results[1].content.id).toBe("users-service");
       expect(result.results[1].similarity).toBe(0.78);
 
       // Verify embedding was generated for the query
@@ -2804,6 +2826,9 @@ describe("ContractsService", () => {
         }),
       );
 
+      // Verify getAllContracts was called
+      expect(service.getAllContracts).toHaveBeenCalled();
+
       expect(mockSession.close).toHaveBeenCalled();
     });
 
@@ -2816,6 +2841,7 @@ describe("ContractsService", () => {
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
       mockSession.run.mockResolvedValue({ records: [] });
+      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
 
       await service.searchByDescription(query, customLimit);
 
@@ -2835,6 +2861,7 @@ describe("ContractsService", () => {
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
       mockSession.run.mockResolvedValue({ records: [] });
+      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
 
       const result = await service.searchByDescription(query, 10);
 
@@ -2910,6 +2937,7 @@ describe("ContractsService", () => {
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
       mockSession.run.mockResolvedValue({ records: [] });
+      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
 
       await service.searchByDescription(query, 10);
 
@@ -2932,6 +2960,7 @@ describe("ContractsService", () => {
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
       mockSession.run.mockResolvedValue({ records: [] });
+      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
 
       await service.searchByDescription(query, 10);
 
@@ -2950,6 +2979,7 @@ describe("ContractsService", () => {
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
       mockSession.run.mockResolvedValue({ records: [] });
+      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
 
       await service.searchByDescription(query, 10);
 
@@ -2968,6 +2998,7 @@ describe("ContractsService", () => {
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
       mockSession.run.mockResolvedValue({ records: [] });
+      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
 
       await service.searchByDescription(query, 10);
 
@@ -2986,12 +3017,23 @@ describe("ContractsService", () => {
           get: (field: string) => {
             const data = {
               module_id: "test-module",
-              type: "service",
-              description: "Test module description",
-              category: "backend",
               similarity: 0.95,
             };
             return data[field];
+          },
+        },
+      ];
+
+      const mockContracts = [
+        {
+          fileName: "test-module.yml",
+          filePath: "/contracts/test-module.yml",
+          fileHash: "hash123",
+          content: {
+            id: "test-module",
+            type: "service",
+            description: "Test module description",
+            category: "backend",
           },
         },
       ];
@@ -3000,13 +3042,18 @@ describe("ContractsService", () => {
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
       mockSession.run.mockResolvedValue({ records: mockResults });
+      jest.spyOn(service, "getAllContracts").mockResolvedValue(mockContracts);
 
       const result = await service.searchByDescription(query, 10);
 
-      expect(result.results[0]).toHaveProperty("module_id");
-      expect(result.results[0]).toHaveProperty("type");
-      expect(result.results[0]).toHaveProperty("description");
-      expect(result.results[0]).toHaveProperty("category");
+      expect(result.results[0]).toHaveProperty("fileName");
+      expect(result.results[0]).toHaveProperty("filePath");
+      expect(result.results[0]).toHaveProperty("fileHash");
+      expect(result.results[0]).toHaveProperty("content");
+      expect(result.results[0].content).toHaveProperty("id");
+      expect(result.results[0].content).toHaveProperty("type");
+      expect(result.results[0].content).toHaveProperty("description");
+      expect(result.results[0].content).toHaveProperty("category");
       expect(result.results[0]).toHaveProperty("similarity");
     });
 
@@ -3018,6 +3065,7 @@ describe("ContractsService", () => {
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
       mockSession.run.mockResolvedValue({ records: [] });
+      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
 
       const result = await service.searchByDescription(query, 10);
 
@@ -3034,6 +3082,7 @@ describe("ContractsService", () => {
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
       mockSession.run.mockResolvedValue({ records: [] });
+      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
 
       const result = await service.searchByDescription(longQuery, 10);
 
@@ -3050,12 +3099,23 @@ describe("ContractsService", () => {
           get: (field: string) => {
             const data = {
               module_id: `service-${i}`,
-              type: "service",
-              description: `Service ${i}`,
-              category: "backend",
               similarity: 0.9 - i * 0.1,
             };
             return data[field];
+          },
+        }));
+
+      const mockContracts = Array(5)
+        .fill(null)
+        .map((_, i) => ({
+          fileName: `service-${i}.yml`,
+          filePath: `/contracts/service-${i}.yml`,
+          fileHash: `hash${i}`,
+          content: {
+            id: `service-${i}`,
+            type: "service",
+            description: `Service ${i}`,
+            category: "backend",
           },
         }));
 
@@ -3063,6 +3123,7 @@ describe("ContractsService", () => {
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
       mockSession.run.mockResolvedValue({ records: mockResults });
+      jest.spyOn(service, "getAllContracts").mockResolvedValue(mockContracts);
 
       const result = await service.searchByDescription(query, 10);
 
@@ -3070,9 +3131,62 @@ describe("ContractsService", () => {
       expect(result.results).toHaveLength(5);
       // Verify all modules are correctly mapped
       result.results.forEach((res, i) => {
-        expect(res.module_id).toBe(`service-${i}`);
+        expect(res.content.id).toBe(`service-${i}`);
+        expect(res.fileName).toBe(`service-${i}.yml`);
         expect(res.similarity).toBe(0.9 - i * 0.1);
       });
+    });
+
+    it("should filter out modules found in Neo4j but not in contract files", async () => {
+      const query = "test query";
+      const mockEmbedding = [0.1, 0.2, 0.3];
+      const mockResults = [
+        {
+          get: (field: string) => {
+            const data = {
+              module_id: "existing-module",
+              similarity: 0.95,
+            };
+            return data[field];
+          },
+        },
+        {
+          get: (field: string) => {
+            const data = {
+              module_id: "missing-module",
+              similarity: 0.85,
+            };
+            return data[field];
+          },
+        },
+      ];
+
+      const mockContracts = [
+        {
+          fileName: "existing-module.yml",
+          filePath: "/contracts/existing-module.yml",
+          fileHash: "hash123",
+          content: {
+            id: "existing-module",
+            type: "service",
+            description: "Existing module",
+            category: "backend",
+          },
+        },
+      ];
+
+      jest
+        .spyOn(embeddingService, "generateEmbedding")
+        .mockResolvedValue(mockEmbedding);
+      mockSession.run.mockResolvedValue({ records: mockResults });
+      jest.spyOn(service, "getAllContracts").mockResolvedValue(mockContracts);
+
+      const result = await service.searchByDescription(query, 10);
+
+      // Should only return the module that exists in contract files
+      expect(result.resultsCount).toBe(1);
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].content.id).toBe("existing-module");
     });
 
     it("should always close session even on error", async () => {

--- a/backend/src/contracts/dto/search-by-description-response.dto.ts
+++ b/backend/src/contracts/dto/search-by-description-response.dto.ts
@@ -1,32 +1,34 @@
 import { ApiProperty } from "@nestjs/swagger";
+import { Contract } from "../contract.schema";
 
 /**
  * DTO for a single module search result
+ * Includes full contract information plus similarity score
  */
 export class ModuleSearchResultDto {
   @ApiProperty({
-    description: "The module ID",
-    example: "users-service",
+    description: "The name of the contract file",
+    example: "example-contract.yml",
   })
-  module_id: string;
+  fileName: string;
 
   @ApiProperty({
-    description: "The module type",
-    example: "service",
+    description: "The full path to the contract file",
+    example: "/contracts/example-contract.yml",
   })
-  type: string;
+  filePath: string;
 
   @ApiProperty({
-    description: "The module description",
-    example: "Service for managing user data and authentication",
+    description: "The parsed contract content",
+    type: "object",
   })
-  description: string;
+  content: Contract;
 
   @ApiProperty({
-    description: "The module category",
-    example: "backend",
+    description: "SHA256 hash of the contract file content",
+    example: "a3d2f1e8b9c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1",
   })
-  category: string;
+  fileHash: string;
 
   @ApiProperty({
     description: "Similarity score (0-1, where 1 is most similar)",


### PR DESCRIPTION
Return the same contract information from `contracts/search` as from the `contracts` endpoint to ensure data consistency.

---
Linear Issue: [PIA-50](https://linear.app/piarsoftware/issue/PIA-50/return-the-same-contract-information-from-contractssearch-like-in)

<a href="https://cursor.com/background-agent?bcId=bc-6b7724ad-004e-4ab8-85cd-1cdc6dde79d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6b7724ad-004e-4ab8-85cd-1cdc6dde79d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

