### PR TITLE
Contract component unification

### DIFF
--- a/frontend/src/components/ContractCard.tsx
+++ b/frontend/src/components/ContractCard.tsx
@@ -1,0 +1,71 @@
+import {
+  Card,
+  CardContent,
+  Box,
+  Stack,
+  Typography,
+  Chip
+} from '@mui/material';
+
+export interface ContractCardProps {
+  fileName: string;
+  filePath: string;
+  id?: string;
+  type?: string;
+  category?: string;
+  description?: string;
+}
+
+function ContractCard({ 
+  fileName, 
+  filePath, 
+  id, 
+  type, 
+  category, 
+  description 
+}: ContractCardProps) {
+  return (
+    <Card variant="outlined" data-testid="contract-card">
+      <CardContent>
+        <Stack spacing={2}>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Typography variant="h6">
+              📄 {fileName}
+            </Typography>
+            {category && (
+              <Chip 
+                label={category} 
+                size="small"
+                color="primary"
+                variant="outlined"
+              />
+            )}
+          </Box>
+          
+          <Typography variant="body2" color="text.secondary">
+            Path: {filePath}
+          </Typography>
+
+          {description && (
+            <Box>
+              <Typography variant="body2" sx={{ fontWeight: 500, mb: 0.5 }}>
+                Description:
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {description}
+              </Typography>
+            </Box>
+          )}
+
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            {id && <Chip label={`ID: ${id}`} size="small" />}
+            {type && <Chip label={`Type: ${type}`} size="small" />}
+            {!description && category && <Chip label={`Category: ${category}`} size="small" />}
+          </Box>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default ContractCard;

--- a/frontend/src/pages/ContractsListPage.tsx
+++ b/frontend/src/pages/ContractsListPage.tsx
@@ -29,14 +29,13 @@ function ContractsListPage() {
   } = useContractsControllerCheckIfContractsModified();
 
   return (
-    <Container maxWidth="md">
+    <Container maxWidth="lg">
       <Box sx={{ 
         minHeight: '100vh', 
         display: 'flex', 
         flexDirection: 'column',
         justifyContent: 'center',
         alignItems: 'center',
-        textAlign: 'center',
         py: 4
       }}>
         <Stack spacing={3} alignItems="center" sx={{ width: '100%' }}>
@@ -48,13 +47,14 @@ function ContractsListPage() {
               backgroundClip: 'text',
               WebkitBackgroundClip: 'text',
               WebkitTextFillColor: 'transparent',
-              fontWeight: 'bold'
+              fontWeight: 'bold',
+              textAlign: 'center',
             }}
           >
             AI Contracts System
           </Typography>
           
-          <Typography variant="h5" color="text.secondary">
+          <Typography variant="h5" color="text.secondary" sx={{ textAlign: 'center' }}>
             AI Coder Agent Contract Systems
           </Typography>
           

--- a/frontend/src/pages/ContractsListPage.tsx
+++ b/frontend/src/pages/ContractsListPage.tsx
@@ -7,7 +7,6 @@ import {
   Stack,
   CircularProgress,
   Alert,
-  Chip,
   Button
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
@@ -15,6 +14,7 @@ import {
   useContractsControllerGetAllContracts,
   useContractsControllerCheckIfContractsModified 
 } from '../api/generated/contracts/contracts';
+import ContractCard from '../components/ContractCard';
 
 function ContractsListPage() {
   const navigate = useNavigate();
@@ -85,23 +85,14 @@ function ContractsListPage() {
               {contracts && contracts.length > 0 && (
                 <Stack spacing={2} sx={{ mt: 2 }}>
                   {contracts.map((contract, index) => (
-                    <Card key={index} variant="outlined" data-testid="contract-card">
-                      <CardContent>
-                        <Typography variant="subtitle1" gutterBottom>
-                          📄 {contract.fileName}
-                        </Typography>
-                        <Typography variant="body2" color="text.secondary">
-                          Path: {contract.filePath}
-                        </Typography>
-                        {contract.content && (
-                          <Box sx={{ mt: 1 }}>
-                            <Chip label={`ID: ${contract.content.id}`} size="small" sx={{ mr: 1 }} />
-                            <Chip label={`Type: ${contract.content.type}`} size="small" sx={{ mr: 1 }} />
-                            <Chip label={`Category: ${contract.content.category}`} size="small" />
-                          </Box>
-                        )}
-                      </CardContent>
-                    </Card>
+                    <ContractCard
+                      key={index}
+                      fileName={contract.fileName}
+                      filePath={contract.filePath}
+                      id={contract.content?.id as string}
+                      type={contract.content?.type as string}
+                      category={contract.content?.category as string}
+                    />
                   ))}
                 </Stack>
               )}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,17 +1,15 @@
 import { 
   Container, 
   Typography, 
-  Card, 
-  CardContent, 
   Box,
   Stack,
   TextField,
   InputAdornment,
-  Chip,
   Alert
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import { useState } from 'react';
+import ContractCard from '../components/ContractCard';
 
 // Mock data for search results
 const mockContracts = [
@@ -122,41 +120,15 @@ function SearchPage() {
               </Typography>
               <Stack spacing={2}>
                 {filteredContracts.map((contract) => (
-                  <Card key={contract.id} variant="outlined">
-                    <CardContent>
-                      <Stack spacing={2}>
-                        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                          <Typography variant="h6">
-                            📄 {contract.fileName}
-                          </Typography>
-                          <Chip 
-                            label={contract.category} 
-                            size="small"
-                            color="primary"
-                            variant="outlined"
-                          />
-                        </Box>
-                        
-                        <Typography variant="body2" color="text.secondary">
-                          Path: {contract.filePath}
-                        </Typography>
-
-                        <Box>
-                          <Typography variant="body2" sx={{ fontWeight: 500, mb: 0.5 }}>
-                            Description:
-                          </Typography>
-                          <Typography variant="body2" color="text.secondary">
-                            {contract.description}
-                          </Typography>
-                        </Box>
-
-                        <Box sx={{ display: 'flex', gap: 1 }}>
-                          <Chip label={`ID: ${contract.id}`} size="small" />
-                          <Chip label={`Type: ${contract.type}`} size="small" />
-                        </Box>
-                      </Stack>
-                    </CardContent>
-                  </Card>
+                  <ContractCard
+                    key={contract.id}
+                    fileName={contract.fileName}
+                    filePath={contract.filePath}
+                    id={contract.id}
+                    type={contract.type}
+                    category={contract.category}
+                    description={contract.description}
+                  />
                 ))}
               </Stack>
             </>


### PR DESCRIPTION
Unify the contract display component to reuse it across the main and search pages.

The existing contract component on the search page was extracted into a new `ContractCard` component, which is now used by both `SearchPage.tsx` and `ContractsListPage.tsx` to ensure consistency and reduce code duplication.

---
Linear Issue: [PIA-58](https://linear.app/piarsoftware/issue/PIA-58/contract-component-unification)

<a href="https://cursor.com/background-agent?bcId=bc-9550e6db-7b6f-4b21-8659-d05d9da0dd74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9550e6db-7b6f-4b21-8659-d05d9da0dd74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

