### PR TITLE
Contract types endpoint

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -48,6 +48,31 @@
         ]
       }
     },
+    "/api/contracts/types": {
+      "get": {
+        "operationId": "ContractsController_getContractTypes",
+        "summary": "Get all unique contract types",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Returns all unique contract types found in the system",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContractTypesResponseDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to retrieve contract types"
+          }
+        },
+        "tags": [
+          "contracts"
+        ]
+      }
+    },
     "/api/contracts/validate": {
       "get": {
         "operationId": "ContractsController_validateContracts",
@@ -251,6 +276,32 @@
           "filePath",
           "content",
           "fileHash"
+        ]
+      },
+      "ContractTypesResponseDto": {
+        "type": "object",
+        "properties": {
+          "types": {
+            "description": "Array of unique contract types found in the system",
+            "example": [
+              "controller",
+              "service",
+              "component"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "count": {
+            "type": "number",
+            "description": "Total count of unique contract types",
+            "example": 3
+          }
+        },
+        "required": [
+          "types",
+          "count"
         ]
       },
       "ValidationErrorDto": {

--- a/backend/src/contracts/contracts.controller.spec.ts
+++ b/backend/src/contracts/contracts.controller.spec.ts
@@ -70,6 +70,7 @@ describe("ContractsController", () => {
             checkIfContractsModified: jest.fn(),
             getModuleRelations: jest.fn(),
             searchByDescription: jest.fn(),
+            getContractTypes: jest.fn(),
           },
         },
       ],
@@ -1497,6 +1498,197 @@ describe("ContractsController", () => {
 
       // Note: Controller validates trimmed query, but passes original to service
       expect(service.searchByDescription).toHaveBeenCalledWith(query, 10);
+    });
+  });
+
+  describe("getContractTypes", () => {
+    it("should return all unique contract types", async () => {
+      const mockTypesResult = {
+        types: ["controller", "service", "component"],
+        count: 3,
+      };
+
+      jest
+        .spyOn(service, "getContractTypes")
+        .mockResolvedValue(mockTypesResult);
+
+      const result = await controller.getContractTypes();
+
+      expect(result).toEqual(mockTypesResult);
+      expect(result.types).toHaveLength(3);
+      expect(result.count).toBe(3);
+      expect(service.getContractTypes).toHaveBeenCalled();
+    });
+
+    it("should return sorted types alphabetically", async () => {
+      const mockTypesResult = {
+        types: ["component", "controller", "service"],
+        count: 3,
+      };
+
+      jest
+        .spyOn(service, "getContractTypes")
+        .mockResolvedValue(mockTypesResult);
+
+      const result = await controller.getContractTypes();
+
+      // Verify types are sorted
+      const sortedTypes = [...result.types].sort();
+      expect(result.types).toEqual(sortedTypes);
+    });
+
+    it("should return empty array when no contracts exist", async () => {
+      const mockEmptyResult = {
+        types: [],
+        count: 0,
+      };
+
+      jest
+        .spyOn(service, "getContractTypes")
+        .mockResolvedValue(mockEmptyResult);
+
+      const result = await controller.getContractTypes();
+
+      expect(result.types).toEqual([]);
+      expect(result.count).toBe(0);
+    });
+
+    it("should return unique types without duplicates", async () => {
+      const mockTypesResult = {
+        types: ["controller", "service"],
+        count: 2,
+      };
+
+      jest
+        .spyOn(service, "getContractTypes")
+        .mockResolvedValue(mockTypesResult);
+
+      const result = await controller.getContractTypes();
+
+      // Check for uniqueness
+      const uniqueTypes = new Set(result.types);
+      expect(uniqueTypes.size).toBe(result.types.length);
+    });
+
+    it("should include all expected type fields in response", async () => {
+      const mockTypesResult = {
+        types: ["controller", "service", "component", "repository"],
+        count: 4,
+      };
+
+      jest
+        .spyOn(service, "getContractTypes")
+        .mockResolvedValue(mockTypesResult);
+
+      const result = await controller.getContractTypes();
+
+      expect(result).toHaveProperty("types");
+      expect(result).toHaveProperty("count");
+      expect(Array.isArray(result.types)).toBe(true);
+      expect(typeof result.count).toBe("number");
+    });
+
+    it("should return count matching types array length", async () => {
+      const mockTypesResult = {
+        types: ["controller", "service", "component"],
+        count: 3,
+      };
+
+      jest
+        .spyOn(service, "getContractTypes")
+        .mockResolvedValue(mockTypesResult);
+
+      const result = await controller.getContractTypes();
+
+      expect(result.count).toBe(result.types.length);
+    });
+
+    it("should handle single type correctly", async () => {
+      const mockTypesResult = {
+        types: ["service"],
+        count: 1,
+      };
+
+      jest
+        .spyOn(service, "getContractTypes")
+        .mockResolvedValue(mockTypesResult);
+
+      const result = await controller.getContractTypes();
+
+      expect(result.types).toHaveLength(1);
+      expect(result.types[0]).toBe("service");
+      expect(result.count).toBe(1);
+    });
+
+    it("should handle many types correctly", async () => {
+      const manyTypes = Array.from({ length: 20 }, (_, i) => `type-${i}`);
+      const mockTypesResult = {
+        types: manyTypes,
+        count: 20,
+      };
+
+      jest
+        .spyOn(service, "getContractTypes")
+        .mockResolvedValue(mockTypesResult);
+
+      const result = await controller.getContractTypes();
+
+      expect(result.types).toHaveLength(20);
+      expect(result.count).toBe(20);
+    });
+
+    it("should throw InternalServerErrorException when service fails", async () => {
+      jest
+        .spyOn(service, "getContractTypes")
+        .mockRejectedValue(new Error("Failed to get contract types"));
+
+      await expect(controller.getContractTypes()).rejects.toThrow(
+        InternalServerErrorException,
+      );
+
+      expect(service.getContractTypes).toHaveBeenCalled();
+    });
+
+    it("should include error details in InternalServerErrorException", async () => {
+      const errorMessage = "Database connection failed";
+      jest
+        .spyOn(service, "getContractTypes")
+        .mockRejectedValue(new Error(errorMessage));
+
+      try {
+        await controller.getContractTypes();
+        fail("Should have thrown InternalServerErrorException");
+      } catch (error) {
+        expect(error).toBeInstanceOf(InternalServerErrorException);
+        expect(error.message).toContain("Failed to get contract types");
+        expect(error.message).toContain(errorMessage);
+      }
+    });
+
+    it("should propagate service errors properly", async () => {
+      jest
+        .spyOn(service, "getContractTypes")
+        .mockRejectedValue(new Error("CONTRACTS_PATH not set"));
+
+      await expect(controller.getContractTypes()).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+
+    it("should verify service method is called without parameters", async () => {
+      const mockTypesResult = {
+        types: ["controller"],
+        count: 1,
+      };
+
+      const getContractTypesSpy = jest
+        .spyOn(service, "getContractTypes")
+        .mockResolvedValue(mockTypesResult);
+
+      await controller.getContractTypes();
+
+      expect(getContractTypesSpy).toHaveBeenCalledWith();
+      expect(getContractTypesSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/backend/src/contracts/contracts.controller.ts
+++ b/backend/src/contracts/contracts.controller.ts
@@ -16,6 +16,7 @@ import { ApplyResponseDto } from "./dto/apply-response.dto";
 import { CheckModifiedResponseDto } from "./dto/check-modified-response.dto";
 import { ModuleRelationsResponseDto } from "./dto/module-relations-response.dto";
 import { SearchByDescriptionResponseDto } from "./dto/search-by-description-response.dto";
+import { ContractTypesResponseDto } from "./dto/contract-types-response.dto";
 
 @ApiTags("contracts")
 @Controller("contracts")
@@ -31,6 +32,27 @@ export class ContractsController {
   })
   async getAllContracts(): Promise<ContractFileDto[]> {
     return this.contractsService.getAllContracts();
+  }
+
+  @Get("types")
+  @ApiOperation({ summary: "Get all unique contract types" })
+  @ApiResponse({
+    status: 200,
+    description: "Returns all unique contract types found in the system",
+    type: ContractTypesResponseDto,
+  })
+  @ApiResponse({
+    status: 500,
+    description: "Failed to retrieve contract types",
+  })
+  async getContractTypes(): Promise<ContractTypesResponseDto> {
+    try {
+      return await this.contractsService.getContractTypes();
+    } catch (error) {
+      throw new InternalServerErrorException(
+        `Failed to get contract types: ${error.message}`,
+      );
+    }
   }
 
   @Get("validate")

--- a/backend/src/contracts/contracts.service.spec.ts
+++ b/backend/src/contracts/contracts.service.spec.ts
@@ -3086,4 +3086,106 @@ describe("ContractsService", () => {
       expect(mockSession.close).toHaveBeenCalled();
     });
   });
+
+  describe("getContractTypes", () => {
+    const testFixturesPath = path.join(__dirname, "test-fixtures");
+
+    it("should return all unique contract types", async () => {
+      const validPattern = path.join(testFixturesPath, "valid-*.yml");
+      jest.spyOn(configService, "get").mockReturnValue(validPattern);
+
+      const result = await service.getContractTypes();
+
+      expect(result).toBeDefined();
+      expect(result.types).toBeDefined();
+      expect(result.count).toBeDefined();
+      expect(Array.isArray(result.types)).toBe(true);
+      expect(result.count).toBe(result.types.length);
+    });
+
+    it("should return unique types without duplicates", async () => {
+      const validPattern = path.join(testFixturesPath, "valid-*.yml");
+      jest.spyOn(configService, "get").mockReturnValue(validPattern);
+
+      const result = await service.getContractTypes();
+
+      // Check for uniqueness
+      const uniqueTypes = new Set(result.types);
+      expect(uniqueTypes.size).toBe(result.types.length);
+    });
+
+    it("should return sorted types alphabetically", async () => {
+      const validPattern = path.join(testFixturesPath, "valid-*.yml");
+      jest.spyOn(configService, "get").mockReturnValue(validPattern);
+
+      const result = await service.getContractTypes();
+
+      // Check if sorted
+      const sortedTypes = [...result.types].sort();
+      expect(result.types).toEqual(sortedTypes);
+    });
+
+    it("should return empty array when no contracts exist", async () => {
+      const nonExistentPattern = path.join(testFixturesPath, "non-existent-*.yml");
+      jest.spyOn(configService, "get").mockReturnValue(nonExistentPattern);
+
+      const result = await service.getContractTypes();
+
+      expect(result.types).toEqual([]);
+      expect(result.count).toBe(0);
+    });
+
+    it("should handle contracts with different types correctly", async () => {
+      // Use all valid contracts to get multiple types
+      const allValidPattern = path.join(testFixturesPath, "valid-*.yml");
+      jest.spyOn(configService, "get").mockReturnValue(allValidPattern);
+
+      const result = await service.getContractTypes();
+
+      // Verify we got the expected types from test fixtures
+      expect(result.types).toContain("service");
+      expect(result.count).toBeGreaterThan(0);
+    });
+
+    it("should throw error when CONTRACTS_PATH is not set", async () => {
+      jest.spyOn(configService, "get").mockReturnValue(undefined);
+
+      await expect(service.getContractTypes()).rejects.toThrow(
+        "Failed to get contract types: CONTRACTS_PATH environment variable is not set",
+      );
+    });
+
+    it("should handle file read errors gracefully", async () => {
+      const invalidPattern = path.join("/invalid/path/*.yml");
+      jest.spyOn(configService, "get").mockReturnValue(invalidPattern);
+
+      const result = await service.getContractTypes();
+
+      // Should return empty array when no files are found
+      expect(result.types).toEqual([]);
+      expect(result.count).toBe(0);
+    });
+
+    it("should include only valid contract types from parseable files", async () => {
+      const allPattern = path.join(testFixturesPath, "*.yml");
+      jest.spyOn(configService, "get").mockReturnValue(allPattern);
+
+      const result = await service.getContractTypes();
+
+      // All types should be non-empty strings
+      result.types.forEach((type) => {
+        expect(typeof type).toBe("string");
+        expect(type.length).toBeGreaterThan(0);
+      });
+    });
+
+    it("should return count matching types array length", async () => {
+      const validPattern = path.join(testFixturesPath, "valid-*.yml");
+      jest.spyOn(configService, "get").mockReturnValue(validPattern);
+
+      const result = await service.getContractTypes();
+
+      expect(result.count).toBe(result.types.length);
+    });
+  });
 });

--- a/backend/src/contracts/contracts.service.ts
+++ b/backend/src/contracts/contracts.service.ts
@@ -911,6 +911,38 @@ export class ContractsService implements OnModuleInit {
   }
 
   /**
+   * Get all unique contract types from the current contracts
+   * @returns Object with array of unique contract types and their count
+   */
+  async getContractTypes(): Promise<{ types: string[]; count: number }> {
+    try {
+      // Get all contracts
+      const contracts = await this.getAllContracts();
+
+      // Extract unique types
+      const typesSet = new Set<string>();
+      contracts.forEach((contract) => {
+        if (contract.content.type) {
+          typesSet.add(contract.content.type);
+        }
+      });
+
+      // Convert to sorted array
+      const types = Array.from(typesSet).sort();
+
+      this.logger.log(`Found ${types.length} unique contract types: ${types.join(", ")}`);
+
+      return {
+        types,
+        count: types.length,
+      };
+    } catch (error) {
+      this.logger.error("Error getting contract types:", error.message);
+      throw new Error(`Failed to get contract types: ${error.message}`);
+    }
+  }
+
+  /**
    * Search for modules by description using embedding similarity
    * @param query The search query text
    * @param limit Maximum number of results to return (default: 10)

--- a/backend/src/contracts/dto/contract-types-response.dto.ts
+++ b/backend/src/contracts/dto/contract-types-response.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+/**
+ * DTO for contract types response
+ */
+export class ContractTypesResponseDto {
+  @ApiProperty({
+    description: "Array of unique contract types found in the system",
+    example: ["controller", "service", "component"],
+    type: [String],
+  })
+  types: string[];
+
+  @ApiProperty({
+    description: "Total count of unique contract types",
+    example: 3,
+  })
+  count: number;
+}


### PR DESCRIPTION
Add an endpoint `GET /api/contracts/types` to return all unique contract types and their count.

This PR resolves Linear issue PIA-53 by providing an API endpoint to retrieve a list of all distinct contract types present in the system, along with comprehensive test coverage.

---
Linear Issue: [PIA-53](https://linear.app/piarsoftware/issue/PIA-53/endpoint-returning-all-contract-types)

<a href="https://cursor.com/background-agent?bcId=bc-6df2df81-e4ca-4adf-97b9-6a4af8411481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6df2df81-e4ca-4adf-97b9-6a4af8411481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

