### PR TITLE
Search page type selector

### DIFF
--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -26,6 +26,14 @@ const mockCategories = [
   { value: 'component', label: 'Component' }
 ];
 
+// Mock types
+const mockTypes = [
+  { value: 'all', label: 'All Types' },
+  { value: 'controller', label: 'Controller' },
+  { value: 'service', label: 'Service' },
+  { value: 'component', label: 'Component' }
+];
+
 // Mock data for search results
 const mockContracts = [
   {
@@ -73,16 +81,22 @@ const mockContracts = [
 function SearchPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('all');
+  const [selectedType, setSelectedType] = useState('all');
 
   const handleCategoryChange = (event: SelectChangeEvent) => {
     setSelectedCategory(event.target.value);
   };
 
-  // Filter contracts based on search query and category (case-insensitive)
+  const handleTypeChange = (event: SelectChangeEvent) => {
+    setSelectedType(event.target.value);
+  };
+
+  // Filter contracts based on search query, category, and type (case-insensitive)
   const filteredContracts = mockContracts.filter(contract => {
     const matchesSearch = contract.description.toLowerCase().includes(searchQuery.toLowerCase());
     const matchesCategory = selectedCategory === 'all' || contract.category === selectedCategory;
-    return matchesSearch && matchesCategory;
+    const matchesType = selectedType === 'all' || contract.type === selectedType;
+    return matchesSearch && matchesCategory && matchesType;
   });
 
   return (
@@ -102,7 +116,7 @@ function SearchPage() {
               Search Contracts
             </Typography>
             <Typography variant="body1" color="text.secondary">
-              Search contracts by description and filter by category
+              Search contracts by description and filter by category and type
             </Typography>
           </Box>
           
@@ -159,6 +173,37 @@ function SearchPage() {
                 {mockCategories.map((category) => (
                   <MenuItem key={category.value} value={category.value}>
                     {category.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            {/* Type Select */}
+            <FormControl 
+              sx={{ 
+                minWidth: { xs: '100%', md: 240 },
+                '& .MuiOutlinedInput-root': {
+                  backgroundColor: 'background.paper',
+                }
+              }}
+            >
+              <InputLabel id="type-select-label">Type</InputLabel>
+              <Select
+                labelId="type-select-label"
+                id="type-select"
+                name="type"
+                value={selectedType}
+                label="Type"
+                onChange={handleTypeChange}
+                startAdornment={
+                  <InputAdornment position="start">
+                    <FilterListIcon />
+                  </InputAdornment>
+                }
+              >
+                {mockTypes.map((type) => (
+                  <MenuItem key={type.value} value={type.value}>
+                    {type.label}
                   </MenuItem>
                 ))}
               </Select>

--- a/frontend/tests/pages/SearchPage.ts
+++ b/frontend/tests/pages/SearchPage.ts
@@ -9,6 +9,7 @@ export class SearchPage extends BasePage {
   readonly pageSubtitle: Locator;
   readonly searchInput: Locator;
   readonly categorySelect: Locator;
+  readonly typeSelect: Locator;
   readonly infoAlert: Locator;
   readonly warningAlert: Locator;
   readonly resultsCount: Locator;
@@ -17,9 +18,10 @@ export class SearchPage extends BasePage {
   constructor(page: Page) {
     super(page);
     this.pageTitle = page.getByRole('heading', { name: 'Search Contracts', level: 1 });
-    this.pageSubtitle = page.getByText('Search contracts by description and filter by category');
+    this.pageSubtitle = page.getByText('Search contracts by description and filter by category and type');
     this.searchInput = page.getByPlaceholder('Search by description...');
     this.categorySelect = page.locator('#category-select');
+    this.typeSelect = page.locator('#type-select');
     this.infoAlert = page.locator('[role="alert"]').filter({ hasText: 'Start typing to search' });
     this.warningAlert = page.locator('[role="alert"]').filter({ hasText: 'No contracts found' });
     this.resultsCount = page.getByText(/Found \d+ contracts?/);
@@ -56,6 +58,24 @@ export class SearchPage extends BasePage {
     // MUI Select uses a hidden input to store the value
     // Use the name attribute to find the hidden input
     const hiddenInput = this.page.locator('input[name="category"]');
+    return await hiddenInput.inputValue();
+  }
+
+  /**
+   * Select a type from the dropdown
+   */
+  async selectType(type: string) {
+    await this.typeSelect.click();
+    await this.page.getByRole('option', { name: type }).click();
+  }
+
+  /**
+   * Get the currently selected type value
+   */
+  async getSelectedType(): Promise<string> {
+    // MUI Select uses a hidden input to store the value
+    // Use the name attribute to find the hidden input
+    const hiddenInput = this.page.locator('input[name="type"]');
     return await hiddenInput.inputValue();
   }
 


### PR DESCRIPTION
Adds a type selector to the search page to allow filtering contracts by type, as required by PIA-52.

---
Linear Issue: [PIA-52](https://linear.app/piarsoftware/issue/PIA-52/search-page-with-type-selector)

<a href="https://cursor.com/background-agent?bcId=bc-8f1c998f-f054-4cb7-b522-4149a8485b31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f1c998f-f054-4cb7-b522-4149a8485b31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

