### PR TITLE
Search endpoint type category

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -190,14 +190,14 @@
     "/api/contracts/search": {
       "get": {
         "operationId": "ContractsController_searchByDescription",
-        "summary": "Search modules by description using semantic similarity",
-        "description": "Searches for modules using embedding-based semantic similarity. The query description is embedded and compared against stored module embeddings to find the most similar modules. Optionally filter by type and/or category.",
+        "summary": "Search and filter modules",
+        "description": "Search for modules using semantic similarity (when query is provided) and/or filter by type and category. At least one parameter (query, type, or category) must be provided.",
         "parameters": [
           {
             "name": "query",
-            "required": true,
+            "required": false,
             "in": "query",
-            "description": "The search query text to find similar modules",
+            "description": "The search query text to find similar modules using semantic similarity",
             "schema": {
               "example": "user authentication service",
               "type": "string"
@@ -236,7 +236,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns search results ordered by similarity",
+            "description": "Returns search results ordered by similarity (if query provided) or by module_id",
             "content": {
               "application/json": {
                 "schema": {
@@ -246,7 +246,7 @@
             }
           },
           "400": {
-            "description": "Invalid search query (empty or missing)"
+            "description": "At least one parameter (query, type, or category) must be provided"
           },
           "500": {
             "description": "Failed to perform search (embedding service not ready or Neo4j error)"

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -191,7 +191,7 @@
       "get": {
         "operationId": "ContractsController_searchByDescription",
         "summary": "Search modules by description using semantic similarity",
-        "description": "Searches for modules using embedding-based semantic similarity. The query description is embedded and compared against stored module embeddings to find the most similar modules.",
+        "description": "Searches for modules using embedding-based semantic similarity. The query description is embedded and compared against stored module embeddings to find the most similar modules. Optionally filter by type and/or category.",
         "parameters": [
           {
             "name": "query",
@@ -212,6 +212,26 @@
               "example": 10,
               "type": "string"
             }
+          },
+          {
+            "name": "type",
+            "required": false,
+            "in": "query",
+            "description": "Filter results by contract type (e.g., 'controller', 'service')",
+            "schema": {
+              "example": "service",
+              "type": "string"
+            }
+          },
+          {
+            "name": "category",
+            "required": false,
+            "in": "query",
+            "description": "Filter results by contract category (e.g., 'api', 'backend')",
+            "schema": {
+              "example": "backend",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -230,6 +250,32 @@
           },
           "500": {
             "description": "Failed to perform search (embedding service not ready or Neo4j error)"
+          }
+        },
+        "tags": [
+          "contracts"
+        ]
+      }
+    },
+    "/api/contracts/categories": {
+      "get": {
+        "operationId": "ContractsController_getCategories",
+        "summary": "Get all contract categories",
+        "description": "Returns a list of all unique contract category names from the Neo4j database",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Returns array of unique category names",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoriesResponseDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to fetch categories"
           }
         },
         "tags": [
@@ -593,25 +639,24 @@
       "ModuleSearchResultDto": {
         "type": "object",
         "properties": {
-          "module_id": {
+          "fileName": {
             "type": "string",
-            "description": "The module ID",
-            "example": "users-service"
+            "description": "The name of the contract file",
+            "example": "example-contract.yml"
           },
-          "type": {
+          "filePath": {
             "type": "string",
-            "description": "The module type",
-            "example": "service"
+            "description": "The full path to the contract file",
+            "example": "/contracts/example-contract.yml"
           },
-          "description": {
-            "type": "string",
-            "description": "The module description",
-            "example": "Service for managing user data and authentication"
+          "content": {
+            "type": "object",
+            "description": "The parsed contract content"
           },
-          "category": {
+          "fileHash": {
             "type": "string",
-            "description": "The module category",
-            "example": "backend"
+            "description": "SHA256 hash of the contract file content",
+            "example": "a3d2f1e8b9c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1"
           },
           "similarity": {
             "type": "number",
@@ -620,10 +665,10 @@
           }
         },
         "required": [
-          "module_id",
-          "type",
-          "description",
-          "category",
+          "fileName",
+          "filePath",
+          "content",
+          "fileHash",
           "similarity"
         ]
       },
@@ -652,6 +697,26 @@
           "query",
           "resultsCount",
           "results"
+        ]
+      },
+      "CategoriesResponseDto": {
+        "type": "object",
+        "properties": {
+          "categories": {
+            "description": "Array of unique contract category names",
+            "example": [
+              "api",
+              "service",
+              "frontend"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "categories"
         ]
       }
     }

--- a/backend/src/contracts/contracts.controller.spec.ts
+++ b/backend/src/contracts/contracts.controller.spec.ts
@@ -1393,7 +1393,15 @@ describe("ContractsController", () => {
       expect(result.results).toEqual([]);
     });
 
-    it("should throw BadRequestException for empty query", async () => {
+    it("should throw BadRequestException when no parameters are provided", async () => {
+      await expect(
+        controller.searchByDescription(undefined, undefined, undefined, undefined),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(service.searchByDescription).not.toHaveBeenCalled();
+    });
+
+    it("should throw BadRequestException for empty query without other filters", async () => {
       await expect(controller.searchByDescription("")).rejects.toThrow(
         BadRequestException,
       );
@@ -1401,12 +1409,92 @@ describe("ContractsController", () => {
       expect(service.searchByDescription).not.toHaveBeenCalled();
     });
 
-    it("should throw BadRequestException for whitespace-only query", async () => {
+    it("should throw BadRequestException for whitespace-only query without other filters", async () => {
       await expect(controller.searchByDescription("   ")).rejects.toThrow(
         BadRequestException,
       );
 
       expect(service.searchByDescription).not.toHaveBeenCalled();
+    });
+
+    it("should allow filtering by type only without query", async () => {
+      const mockFilteredResults = {
+        query: "",
+        resultsCount: 2,
+        results: mockSearchResults.results.slice(0, 2),
+      };
+
+      jest
+        .spyOn(service, "searchByDescription")
+        .mockResolvedValue(mockFilteredResults);
+
+      const result = await controller.searchByDescription(
+        undefined,
+        undefined,
+        "service",
+      );
+
+      expect(result).toEqual(mockFilteredResults);
+      expect(service.searchByDescription).toHaveBeenCalledWith(
+        undefined,
+        10,
+        "service",
+        undefined,
+      );
+    });
+
+    it("should allow filtering by category only without query", async () => {
+      const mockFilteredResults = {
+        query: "",
+        resultsCount: 2,
+        results: mockSearchResults.results.slice(0, 2),
+      };
+
+      jest
+        .spyOn(service, "searchByDescription")
+        .mockResolvedValue(mockFilteredResults);
+
+      const result = await controller.searchByDescription(
+        undefined,
+        undefined,
+        undefined,
+        "backend",
+      );
+
+      expect(result).toEqual(mockFilteredResults);
+      expect(service.searchByDescription).toHaveBeenCalledWith(
+        undefined,
+        10,
+        undefined,
+        "backend",
+      );
+    });
+
+    it("should allow filtering by type and category without query", async () => {
+      const mockFilteredResults = {
+        query: "",
+        resultsCount: 1,
+        results: [mockSearchResults.results[0]],
+      };
+
+      jest
+        .spyOn(service, "searchByDescription")
+        .mockResolvedValue(mockFilteredResults);
+
+      const result = await controller.searchByDescription(
+        undefined,
+        undefined,
+        "service",
+        "backend",
+      );
+
+      expect(result).toEqual(mockFilteredResults);
+      expect(service.searchByDescription).toHaveBeenCalledWith(
+        undefined,
+        10,
+        "service",
+        "backend",
+      );
     });
 
     it("should throw BadRequestException for invalid limit (not a number)", async () => {

--- a/backend/src/contracts/contracts.controller.spec.ts
+++ b/backend/src/contracts/contracts.controller.spec.ts
@@ -1289,6 +1289,8 @@ describe("ContractsController", () => {
       expect(service.searchByDescription).toHaveBeenCalledWith(
         "user authentication",
         10,
+        undefined,
+        undefined,
       );
     });
 
@@ -1312,6 +1314,8 @@ describe("ContractsController", () => {
       expect(service.searchByDescription).toHaveBeenCalledWith(
         "user authentication",
         5,
+        undefined,
+        undefined,
       );
     });
 
@@ -1325,6 +1329,8 @@ describe("ContractsController", () => {
       expect(service.searchByDescription).toHaveBeenCalledWith(
         "user authentication",
         10,
+        undefined,
+        undefined,
       );
     });
 
@@ -1445,6 +1451,8 @@ describe("ContractsController", () => {
       expect(service.searchByDescription).toHaveBeenCalledWith(
         "test query",
         100,
+        undefined,
+        undefined,
       );
     });
 
@@ -1464,6 +1472,8 @@ describe("ContractsController", () => {
       expect(service.searchByDescription).toHaveBeenCalledWith(
         "test query",
         10,
+        undefined,
+        undefined,
       );
     });
 
@@ -1506,6 +1516,8 @@ describe("ContractsController", () => {
       expect(service.searchByDescription).toHaveBeenCalledWith(
         queryWithSpecialChars,
         10,
+        undefined,
+        undefined,
       );
     });
 
@@ -1523,7 +1535,12 @@ describe("ContractsController", () => {
       const result = await controller.searchByDescription(longQuery);
 
       expect(result.query).toBe(longQuery);
-      expect(service.searchByDescription).toHaveBeenCalledWith(longQuery, 10);
+      expect(service.searchByDescription).toHaveBeenCalledWith(
+        longQuery,
+        10,
+        undefined,
+        undefined,
+      );
     });
 
     it("should handle queries with multiple modules in results", async () => {
@@ -1567,7 +1584,140 @@ describe("ContractsController", () => {
       const result = await controller.searchByDescription(query);
 
       // Note: Controller validates trimmed query, but passes original to service
-      expect(service.searchByDescription).toHaveBeenCalledWith(query, 10);
+      expect(service.searchByDescription).toHaveBeenCalledWith(
+        query,
+        10,
+        undefined,
+        undefined,
+      );
+    });
+
+    it("should filter by type when type parameter is provided", async () => {
+      const mockFilteredResults = {
+        ...mockSearchResults,
+        resultsCount: 1,
+        results: [mockSearchResults.results[0]],
+      };
+
+      jest
+        .spyOn(service, "searchByDescription")
+        .mockResolvedValue(mockFilteredResults);
+
+      const result = await controller.searchByDescription(
+        "user authentication",
+        undefined,
+        "service",
+      );
+
+      expect(result).toEqual(mockFilteredResults);
+      expect(service.searchByDescription).toHaveBeenCalledWith(
+        "user authentication",
+        10,
+        "service",
+        undefined,
+      );
+    });
+
+    it("should filter by category when category parameter is provided", async () => {
+      const mockFilteredResults = {
+        ...mockSearchResults,
+        resultsCount: 2,
+        results: mockSearchResults.results.slice(0, 2),
+      };
+
+      jest
+        .spyOn(service, "searchByDescription")
+        .mockResolvedValue(mockFilteredResults);
+
+      const result = await controller.searchByDescription(
+        "user authentication",
+        undefined,
+        undefined,
+        "backend",
+      );
+
+      expect(result).toEqual(mockFilteredResults);
+      expect(service.searchByDescription).toHaveBeenCalledWith(
+        "user authentication",
+        10,
+        undefined,
+        "backend",
+      );
+    });
+
+    it("should filter by both type and category when both parameters are provided", async () => {
+      const mockFilteredResults = {
+        ...mockSearchResults,
+        resultsCount: 1,
+        results: [mockSearchResults.results[0]],
+      };
+
+      jest
+        .spyOn(service, "searchByDescription")
+        .mockResolvedValue(mockFilteredResults);
+
+      const result = await controller.searchByDescription(
+        "user authentication",
+        undefined,
+        "service",
+        "backend",
+      );
+
+      expect(result).toEqual(mockFilteredResults);
+      expect(service.searchByDescription).toHaveBeenCalledWith(
+        "user authentication",
+        10,
+        "service",
+        "backend",
+      );
+    });
+
+    it("should filter with custom limit and filters", async () => {
+      const mockFilteredResults = {
+        ...mockSearchResults,
+        resultsCount: 1,
+        results: [mockSearchResults.results[0]],
+      };
+
+      jest
+        .spyOn(service, "searchByDescription")
+        .mockResolvedValue(mockFilteredResults);
+
+      const result = await controller.searchByDescription(
+        "user authentication",
+        "20",
+        "service",
+        "backend",
+      );
+
+      expect(result).toEqual(mockFilteredResults);
+      expect(service.searchByDescription).toHaveBeenCalledWith(
+        "user authentication",
+        20,
+        "service",
+        "backend",
+      );
+    });
+
+    it("should return empty results when filters match no modules", async () => {
+      const mockEmptyResults = {
+        query: "user authentication",
+        resultsCount: 0,
+        results: [],
+      };
+
+      jest
+        .spyOn(service, "searchByDescription")
+        .mockResolvedValue(mockEmptyResults);
+
+      const result = await controller.searchByDescription(
+        "user authentication",
+        undefined,
+        "nonexistent-type",
+      );
+
+      expect(result.resultsCount).toBe(0);
+      expect(result.results).toEqual([]);
     });
   });
 

--- a/backend/src/contracts/contracts.controller.ts
+++ b/backend/src/contracts/contracts.controller.ts
@@ -180,7 +180,7 @@ export class ContractsController {
   @ApiOperation({
     summary: "Search modules by description using semantic similarity",
     description:
-      "Searches for modules using embedding-based semantic similarity. The query description is embedded and compared against stored module embeddings to find the most similar modules.",
+      "Searches for modules using embedding-based semantic similarity. The query description is embedded and compared against stored module embeddings to find the most similar modules. Optionally filter by type and/or category.",
   })
   @ApiQuery({
     name: "query",
@@ -192,6 +192,18 @@ export class ContractsController {
     name: "limit",
     description: "Maximum number of results to return (default: 10)",
     example: 10,
+    required: false,
+  })
+  @ApiQuery({
+    name: "type",
+    description: "Filter results by contract type (e.g., 'controller', 'service')",
+    example: "service",
+    required: false,
+  })
+  @ApiQuery({
+    name: "category",
+    description: "Filter results by contract category (e.g., 'api', 'backend')",
+    example: "backend",
     required: false,
   })
   @ApiResponse({
@@ -211,6 +223,8 @@ export class ContractsController {
   async searchByDescription(
     @Query("query") query: string,
     @Query("limit") limit?: string,
+    @Query("type") type?: string,
+    @Query("category") category?: string,
   ): Promise<SearchByDescriptionResponseDto> {
     // Validate query parameter
     if (!query || query.trim().length === 0) {
@@ -232,6 +246,8 @@ export class ContractsController {
       return await this.contractsService.searchByDescription(
         query,
         parsedLimit,
+        type,
+        category,
       );
     } catch (error) {
       if (error.message.includes("Embedding service is not ready")) {


### PR DESCRIPTION
Add type and category filters to the search endpoint to allow for more refined module searches.

---
Linear Issue: [PIA-59](https://linear.app/piarsoftware/issue/PIA-59/search-endpoint-with-type-and-category-filters)

<a href="https://cursor.com/background-agent?bcId=bc-c9e52c82-6f2e-4d2e-b1a9-868bc9d34389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9e52c82-6f2e-4d2e-b1a9-868bc9d34389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

