### PR TITLE
Modified contracts on main

### DIFF
--- a/IMPLEMENTATION_PIA-60.md
+++ b/IMPLEMENTATION_PIA-60.md
@@ -15,6 +15,9 @@ Updated the Contracts List Page to display only modified/new contracts instead o
 - Updated the "no contracts" message to "No modified or new contracts found. All contracts are up to date with the database."
 - Refactored conditional rendering to use ternary operators for better TypeScript type inference
 - Pass the `status` prop to each `ContractCard` component
+- Loading spinner now only shows while contracts are loading (not while checking modifications)
+- Check modifications status is indicated by the button text ("Checking for changes..." vs "Verify Contracts")
+- Separate alerts for check-modified errors and "no changes detected" status appear below the card
 
 **Logic:**
 ```typescript

--- a/IMPLEMENTATION_PIA-60.md
+++ b/IMPLEMENTATION_PIA-60.md
@@ -1,0 +1,116 @@
+# Implementation: PIA-60 - Show Only Modified/New Contracts on Main Page
+
+## Summary
+Updated the Contracts List Page to display only modified/new contracts instead of all contracts. Modified/new contracts are identified by comparing the current contract files with the data stored in Neo4j database using file hash comparison.
+
+## Changes Made
+
+### 1. Frontend - ContractsListPage Component (`frontend/src/pages/ContractsListPage.tsx`)
+
+**Key Changes:**
+- Added filtering logic to show only contracts that appear in the `checkModifiedData.changes` array
+- Created `modifiedContracts` array that filters contracts based on file path matching with changes
+- Added `getContractStatus()` helper function to retrieve the status (modified/added/removed) for each contract
+- Updated the card title from "📋 Contracts List" to "📋 Modified/New Contracts"
+- Updated the "no contracts" message to "No modified or new contracts found. All contracts are up to date with the database."
+- Refactored conditional rendering to use ternary operators for better TypeScript type inference
+- Pass the `status` prop to each `ContractCard` component
+
+**Logic:**
+```typescript
+// Filter contracts to show only modified/new ones
+const modifiedContracts = contracts?.filter(contract => {
+  if (!checkModifiedData?.changes) return false;
+  return checkModifiedData.changes.some(change => 
+    change.filePath === contract.filePath
+  );
+}) || [];
+
+// Get the status for a contract
+const getContractStatus = (filePath: string): 'modified' | 'added' | 'removed' | undefined => {
+  const change = checkModifiedData?.changes?.find(c => c.filePath === filePath);
+  return change?.status;
+};
+```
+
+### 2. Frontend - ContractCard Component (`frontend/src/components/ContractCard.tsx`)
+
+**Key Changes:**
+- Added `status` prop to the `ContractCardProps` interface with type `'modified' | 'added' | 'removed' | undefined`
+- Created `getStatusChip()` helper function that renders a colored status badge:
+  - **✨ New** (green/success) for added contracts
+  - **🔄 Modified** (orange/warning) for modified contracts
+  - **🗑️ Removed** (red/error) for removed contracts
+- Updated the card header layout to display the status chip alongside the category chip
+- Status chip is only displayed when the `status` prop is provided
+
+### 3. Integration Tests Updates
+
+#### Updated Test Fixtures (`frontend/tests/fixtures/contracts-data.ts`)
+- Mock data already included `mockCheckModified` and `mockCheckModifiedApiResponses` for testing
+
+#### Updated Page Object (`frontend/tests/pages/ContractsListPage.ts`)
+- Changed `contractsCardTitle` locator to look for "📋 Modified/New Contracts"
+- Changed `noContractsAlert` locator to match new text: "No modified or new contracts found"
+
+#### Updated Tests (`frontend/tests/contracts-list.spec.ts`)
+- Updated all tests to mock both `/api/contracts` and `/api/contracts/check-if-contract-modified` endpoints
+- Renamed test: "should display contracts when API returns data" → "should display only modified/new contracts when API returns data with changes"
+- Renamed test: "should display 'No contracts found' message" → "should display 'No modified or new contracts' message when there are no changes"
+- Added new test: "should display error message when check-modified API fails"
+- Updated test: "should display all contract details correctly" → "should display modified contract details correctly with status badge"
+- Updated multiple tests to create appropriate mock responses for the check-modified endpoint
+- Updated expectations to reflect that only modified/new contracts are shown
+
+#### Updated Verify Button Tests (`frontend/tests/contract-verify-button.spec.ts`)
+- All tests already properly mock both endpoints
+- Tests remain valid as the button behavior is unchanged
+
+## Acceptance Criteria Met
+
+✅ **Show only modified/new contracts on main page**
+- The page now filters and displays only contracts that appear in the `changes` array from the check-modified endpoint
+
+✅ **Modified/new contracts mean contract with changes not saved in Neo4j**
+- Contracts are identified as modified/new by the backend's `checkIfContractsModified` endpoint, which compares file hashes
+
+✅ **These changes can be compared with hashes if it was modified**
+- The backend uses SHA256 file hashes to detect modifications by comparing:
+  - `currentHash`: Hash of the current contract file
+  - `storedHash`: Hash stored in Neo4j database
+  - If hashes differ → status is "modified"
+  - If storedHash is null → status is "added"
+
+## Technical Details
+
+### How It Works
+1. The page fetches all contracts via `/api/contracts`
+2. Simultaneously, it checks for modifications via `/api/contracts/check-if-contract-modified`
+3. The check-modified endpoint returns a list of changes with:
+   - `moduleId`: The contract's module ID
+   - `fileName`: The contract file name
+   - `filePath`: The full path to the contract
+   - `currentHash`: Current SHA256 hash
+   - `storedHash`: Hash from Neo4j (null if new)
+   - `status`: "modified" | "added" | "removed"
+4. The frontend filters the contracts array to include only those with matching `filePath` in the changes array
+5. Each displayed contract shows a status badge indicating whether it's new, modified, or removed
+
+### User Experience
+- Users now see only contracts that need attention (modified or new)
+- Status badges provide clear visual indication of the type of change
+- The "Verify Contracts" button remains disabled when no changes are detected
+- Clear messaging when no modified/new contracts exist
+
+## Testing
+- ✅ TypeScript compilation successful
+- ✅ Frontend build successful
+- ✅ All integration tests updated to reflect new behavior
+- ✅ Page object model updated
+- ✅ Test fixtures provide comprehensive mock data
+
+## Files Modified
+1. `frontend/src/pages/ContractsListPage.tsx` - Main page logic
+2. `frontend/src/components/ContractCard.tsx` - Added status badge
+3. `frontend/tests/pages/ContractsListPage.ts` - Updated page object
+4. `frontend/tests/contracts-list.spec.ts` - Updated tests

--- a/frontend/src/components/ContractCard.tsx
+++ b/frontend/src/components/ContractCard.tsx
@@ -14,6 +14,7 @@ export interface ContractCardProps {
   type?: string;
   category?: string;
   description?: string;
+  status?: 'modified' | 'added' | 'removed';
 }
 
 function ContractCard({ 
@@ -22,24 +23,49 @@ function ContractCard({
   id, 
   type, 
   category, 
-  description 
+  description,
+  status
 }: ContractCardProps) {
+  // Map status to chip color and label
+  const getStatusChip = () => {
+    if (!status) return null;
+    
+    const statusConfig = {
+      added: { color: 'success' as const, label: '✨ New', icon: '✨' },
+      modified: { color: 'warning' as const, label: '🔄 Modified', icon: '🔄' },
+      removed: { color: 'error' as const, label: '🗑️ Removed', icon: '🗑️' }
+    };
+    
+    const config = statusConfig[status];
+    return (
+      <Chip 
+        label={config.label}
+        size="small"
+        color={config.color}
+        sx={{ fontWeight: 600 }}
+      />
+    );
+  };
+
   return (
     <Card variant="outlined" data-testid="contract-card">
       <CardContent>
         <Stack spacing={2}>
-          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1, flexWrap: 'wrap' }}>
             <Typography variant="h6">
               📄 {fileName}
             </Typography>
-            {category && (
-              <Chip 
-                label={category} 
-                size="small"
-                color="primary"
-                variant="outlined"
-              />
-            )}
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+              {getStatusChip()}
+              {category && (
+                <Chip 
+                  label={category} 
+                  size="small"
+                  color="primary"
+                  variant="outlined"
+                />
+              )}
+            </Box>
           </Box>
           
           <Typography variant="body2" color="text.secondary">

--- a/frontend/src/pages/ContractsListPage.tsx
+++ b/frontend/src/pages/ContractsListPage.tsx
@@ -28,6 +28,20 @@ function ContractsListPage() {
     error: checkModifiedError 
   } = useContractsControllerCheckIfContractsModified();
 
+  // Filter contracts to show only modified/new ones
+  const modifiedContracts = contracts?.filter(contract => {
+    if (!checkModifiedData?.changes) return false;
+    return checkModifiedData.changes.some(change => 
+      change.filePath === contract.filePath
+    );
+  }) || [];
+
+  // Get the status for a contract
+  const getContractStatus = (filePath: string): 'modified' | 'added' | 'removed' | undefined => {
+    const change = checkModifiedData?.changes?.find(c => c.filePath === filePath);
+    return change?.status;
+  };
+
   return (
     <Container maxWidth="lg">
       <Box sx={{ 
@@ -61,30 +75,28 @@ function ContractsListPage() {
           <Card sx={{ width: '100%', mt: 2 }}>
             <CardContent>
               <Typography variant="h6" gutterBottom>
-                📋 Contracts List
+                📋 Modified/New Contracts
               </Typography>
               
-              {isLoading && (
+              {(isLoading || isCheckingModified) ? (
                 <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
                   <CircularProgress />
                 </Box>
-              )}
-              
-              {error && (
+              ) : error ? (
                 <Alert severity="error">
                   Error loading contracts: {error instanceof Error ? error.message : 'Unknown error'}
                 </Alert>
-              )}
-              
-              {contracts && contracts.length === 0 && (
-                <Alert severity="info">
-                  No contracts found
+              ) : checkModifiedError ? (
+                <Alert severity="error">
+                  Error checking contract modifications: {(checkModifiedError as Error)?.message || 'Unknown error'}
                 </Alert>
-              )}
-              
-              {contracts && contracts.length > 0 && (
+              ) : modifiedContracts.length === 0 ? (
+                <Alert severity="info">
+                  No modified or new contracts found. All contracts are up to date with the database.
+                </Alert>
+              ) : (
                 <Stack spacing={2} sx={{ mt: 2 }}>
-                  {contracts.map((contract, index) => (
+                  {modifiedContracts.map((contract, index) => (
                     <ContractCard
                       key={index}
                       fileName={contract.fileName}
@@ -92,24 +104,13 @@ function ContractsListPage() {
                       id={contract.content?.id as string}
                       type={contract.content?.type as string}
                       category={contract.content?.category as string}
+                      status={getContractStatus(contract.filePath)}
                     />
                   ))}
                 </Stack>
               )}
             </CardContent>
           </Card>
-
-          {checkModifiedError && (
-            <Alert severity="error" sx={{ mt: 2 }}>
-              Error checking contract modifications: {checkModifiedError instanceof Error ? checkModifiedError.message : 'Unknown error'}
-            </Alert>
-          )}
-
-          {checkModifiedData && !checkModifiedData.hasChanges && (
-            <Alert severity="info" sx={{ mt: 2 }}>
-              No changes detected. All contracts are up to date with the database.
-            </Alert>
-          )}
 
           <Button
             variant="contained"

--- a/frontend/src/pages/ContractsListPage.tsx
+++ b/frontend/src/pages/ContractsListPage.tsx
@@ -78,7 +78,7 @@ function ContractsListPage() {
                 📋 Modified/New Contracts
               </Typography>
               
-              {(isLoading || isCheckingModified) ? (
+              {isLoading ? (
                 <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
                   <CircularProgress />
                 </Box>
@@ -86,15 +86,11 @@ function ContractsListPage() {
                 <Alert severity="error">
                   Error loading contracts: {error instanceof Error ? error.message : 'Unknown error'}
                 </Alert>
-              ) : checkModifiedError ? (
-                <Alert severity="error">
-                  Error checking contract modifications: {(checkModifiedError as Error)?.message || 'Unknown error'}
-                </Alert>
-              ) : modifiedContracts.length === 0 ? (
+              ) : modifiedContracts.length === 0 && !isCheckingModified ? (
                 <Alert severity="info">
                   No modified or new contracts found. All contracts are up to date with the database.
                 </Alert>
-              ) : (
+              ) : modifiedContracts.length > 0 ? (
                 <Stack spacing={2} sx={{ mt: 2 }}>
                   {modifiedContracts.map((contract, index) => (
                     <ContractCard
@@ -108,9 +104,21 @@ function ContractsListPage() {
                     />
                   ))}
                 </Stack>
-              )}
+              ) : null}
             </CardContent>
           </Card>
+
+          {checkModifiedError && (
+            <Alert severity="error" sx={{ mt: 2 }}>
+              Error checking contract modifications: {(checkModifiedError as Error)?.message || 'Unknown error'}
+            </Alert>
+          )}
+
+          {checkModifiedData && !checkModifiedData.hasChanges && (
+            <Alert severity="info" sx={{ mt: 2 }}>
+              No changes detected. All contracts are up to date with the database.
+            </Alert>
+          )}
 
           <Button
             variant="contained"

--- a/frontend/tests/contracts-list.spec.ts
+++ b/frontend/tests/contracts-list.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import { ContractsListPage } from './pages/ContractsListPage';
 import { LoadingSpinner } from './components/LoadingSpinner';
 import { Alert } from './components/Alert';
-import { mockContracts, mockApiResponses } from './fixtures/contracts-data';
+import { mockContracts, mockApiResponses, mockCheckModifiedApiResponses } from './fixtures/contracts-data';
 
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -30,7 +30,7 @@ test.describe('Contracts List Page', () => {
     await expect(contractsPage.pageSubtitle).toHaveText('AI Coder Agent Contract Systems');
     
     await expect(contractsPage.contractsCardTitle).toBeVisible();
-    await expect(contractsPage.contractsCardTitle).toHaveText('📋 Contracts List');
+    await expect(contractsPage.contractsCardTitle).toHaveText('📋 Modified/New Contracts');
   });
 
   test('should show loading spinner while fetching contracts', async ({ page }) => {
@@ -44,6 +44,10 @@ test.describe('Contracts List Page', () => {
         });
       });
 
+      await page.route('**/api/contracts/check-if-contract-modified', async (route) => {
+        await route.fulfill(mockCheckModifiedApiResponses.noChanges);
+      });
+
       await contractsPage.navigate();
 
       const spinner = new LoadingSpinner(contractsPage.loadingSpinner);
@@ -53,20 +57,24 @@ test.describe('Contracts List Page', () => {
     }
   });
 
-  test('should display contracts when API returns data', async ({ page }) => {
-    // Mock API response with sample contracts
+  test('should display only modified/new contracts when API returns data with changes', async ({ page }) => {
+    // Mock API responses - both contracts endpoint and check-modified endpoint
     await page.route('**/api/contracts', async (route) => {
       await route.fulfill(mockApiResponses.success(mockContracts.validContracts));
+    });
+
+    await page.route('**/api/contracts/check-if-contract-modified', async (route) => {
+      await route.fulfill(mockCheckModifiedApiResponses.hasChanges);
     });
 
     await contractsPage.navigate();
     await contractsPage.waitForContractsToLoad();
 
-    // Verify contracts are displayed
+    // Verify only 2 modified/new contracts are displayed (as defined in mockCheckModified.hasChanges)
     const contractsCount = await contractsPage.getContractsCount();
     expect(contractsCount).toBe(2);
 
-    // Verify first contract details
+    // Verify first contract details (modified)
     const firstContract = await contractsPage.getContractDetails(0);
     expect(firstContract.fileName).toBe('example-contract.yml');
     expect(firstContract.filePath).toBe('/contracts/example-contract.yml');
@@ -74,7 +82,7 @@ test.describe('Contracts List Page', () => {
     expect(firstContract.type).toBe('controller');
     expect(firstContract.category).toBe('api');
 
-    // Verify second contract details
+    // Verify second contract details (added)
     const secondContract = await contractsPage.getContractDetails(1);
     expect(secondContract.fileName).toBe('example-dependency.yml');
     expect(secondContract.filePath).toBe('/contracts/example-dependency.yml');
@@ -83,25 +91,33 @@ test.describe('Contracts List Page', () => {
     expect(secondContract.category).toBe('service');
   });
 
-  test('should display "No contracts found" message when API returns empty array', async ({ page }) => {
-    // Mock API response with empty array
+  test('should display "No modified or new contracts" message when there are no changes', async ({ page }) => {
+    // Mock API response with contracts but no changes
     await page.route('**/api/contracts', async (route) => {
-      await route.fulfill(mockApiResponses.empty);
+      await route.fulfill(mockApiResponses.success(mockContracts.validContracts));
+    });
+
+    await page.route('**/api/contracts/check-if-contract-modified', async (route) => {
+      await route.fulfill(mockCheckModifiedApiResponses.noChanges);
     });
 
     await contractsPage.navigate();
     await contractsPage.waitForContractsToLoad();
 
-    // Verify "no contracts" alert is displayed
+    // Verify "no modified or new contracts" alert is displayed
     const noContractsAlert = new Alert(contractsPage.noContractsAlert);
     await noContractsAlert.verifyIsVisible();
-    await noContractsAlert.verifyText('No contracts found');
+    await noContractsAlert.verifyText('No modified or new contracts found');
   });
 
-  test('should display error message when API fails', async ({ page }) => {
+  test('should display error message when contracts API fails', async ({ page }) => {
     // Mock API to return error
     await page.route('**/api/contracts', async (route) => {
       await route.fulfill(mockApiResponses.serverError);
+    });
+
+    await page.route('**/api/contracts/check-if-contract-modified', async (route) => {
+      await route.fulfill(mockCheckModifiedApiResponses.hasChanges);
     });
 
     await contractsPage.navigate();
@@ -111,6 +127,25 @@ test.describe('Contracts List Page', () => {
     const errorAlert = new Alert(contractsPage.errorAlert);
     await errorAlert.verifyIsVisible();
     await errorAlert.verifyText('Error loading contracts');
+  });
+
+  test('should display error message when check-modified API fails', async ({ page }) => {
+    // Mock contracts API to succeed but check-modified to fail
+    await page.route('**/api/contracts', async (route) => {
+      await route.fulfill(mockApiResponses.success(mockContracts.validContracts));
+    });
+
+    await page.route('**/api/contracts/check-if-contract-modified', async (route) => {
+      await route.fulfill(mockCheckModifiedApiResponses.serverError);
+    });
+
+    await contractsPage.navigate();
+    await contractsPage.waitForContractsToLoad();
+
+    // Verify error alert is displayed
+    const errorAlert = new Alert(contractsPage.errorAlert);
+    await errorAlert.verifyIsVisible();
+    await errorAlert.verifyText('Error checking contract modifications');
   });
 
   test('should display error message when network fails', async ({ page }) => {
@@ -119,6 +154,10 @@ test.describe('Contracts List Page', () => {
       await route.abort('failed');
     });
 
+    await page.route('**/api/contracts/check-if-contract-modified', async (route) => {
+      await route.fulfill(mockCheckModifiedApiResponses.hasChanges);
+    });
+
     await contractsPage.navigate();
     await contractsPage.waitForContractsToLoad();
 
@@ -128,10 +167,36 @@ test.describe('Contracts List Page', () => {
     await errorAlert.verifyText('Error loading contracts');
   });
 
-  test('should display all contract details correctly', async ({ page }) => {
-    // Mock API response with detailed contract
+  test('should display modified contract details correctly with status badge', async ({ page }) => {
+    // Create a mock response with single modified contract
+    const singleModifiedContract = {
+      hasChanges: true,
+      totalChanges: 1,
+      modifiedCount: 1,
+      addedCount: 0,
+      removedCount: 0,
+      changes: [
+        {
+          moduleId: 'payment-service',
+          fileName: 'single-contract.yml',
+          filePath: '/contracts/single-contract.yml',
+          currentHash: 'a3d2f1e8b9c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1',
+          storedHash: 'b4e3d2c1b0a9f8e7d6c5b4a3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3',
+          status: 'modified',
+        },
+      ],
+    };
+
     await page.route('**/api/contracts', async (route) => {
       await route.fulfill(mockApiResponses.success([mockContracts.singleContract]));
+    });
+
+    await page.route('**/api/contracts/check-if-contract-modified', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(singleModifiedContract),
+      });
     });
 
     await contractsPage.navigate();
@@ -148,16 +213,58 @@ test.describe('Contracts List Page', () => {
     expect(exists).toBe(true);
   });
 
-  test('should handle multiple contracts with same type', async ({ page }) => {
-    // Mock API response with multiple contracts of same type
+  test('should handle multiple modified contracts with same type', async ({ page }) => {
+    // Create mock data for all 3 service contracts being modified
+    const multipleModifiedContracts = {
+      hasChanges: true,
+      totalChanges: 3,
+      modifiedCount: 3,
+      addedCount: 0,
+      removedCount: 0,
+      changes: [
+        {
+          moduleId: 'service-a',
+          fileName: 'service-a.yml',
+          filePath: '/contracts/service-a.yml',
+          currentHash: 'hash-a',
+          storedHash: 'old-hash-a',
+          status: 'modified' as const,
+        },
+        {
+          moduleId: 'service-b',
+          fileName: 'service-b.yml',
+          filePath: '/contracts/service-b.yml',
+          currentHash: 'hash-b',
+          storedHash: 'old-hash-b',
+          status: 'modified' as const,
+        },
+        {
+          moduleId: 'service-c',
+          fileName: 'service-c.yml',
+          filePath: '/contracts/service-c.yml',
+          currentHash: 'hash-c',
+          storedHash: 'old-hash-c',
+          status: 'modified' as const,
+        },
+      ],
+    };
+
     await page.route('**/api/contracts', async (route) => {
       await route.fulfill(mockApiResponses.success(mockContracts.serviceContracts));
+    });
+
+    await page.route('**/api/contracts/check-if-contract-modified', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(multipleModifiedContracts),
+      });
     });
 
     await contractsPage.navigate();
     await contractsPage.waitForContractsToLoad();
 
-    // Verify all contracts are displayed
+    // Verify all 3 modified contracts are displayed
     const contractsCount = await contractsPage.getContractsCount();
     expect(contractsCount).toBe(3);
 
@@ -168,10 +275,52 @@ test.describe('Contracts List Page', () => {
     expect(fileNames).toContain('service-c.yml');
   });
 
-  test('should handle contracts with different categories', async ({ page }) => {
-    // Mock API response with contracts from different categories
+  test('should handle modified contracts with different categories', async ({ page }) => {
+    // Create mock data for mixed category contracts being modified
+    const mixedModifiedContracts = {
+      hasChanges: true,
+      totalChanges: 3,
+      modifiedCount: 2,
+      addedCount: 1,
+      removedCount: 0,
+      changes: [
+        {
+          moduleId: 'users-controller',
+          fileName: 'api-controller.yml',
+          filePath: '/contracts/api-controller.yml',
+          currentHash: 'hash-api',
+          storedHash: 'old-hash-api',
+          status: 'modified' as const,
+        },
+        {
+          moduleId: 'users-service',
+          fileName: 'business-service.yml',
+          filePath: '/contracts/business-service.yml',
+          currentHash: 'hash-service',
+          storedHash: 'old-hash-service',
+          status: 'modified' as const,
+        },
+        {
+          moduleId: 'users-table',
+          fileName: 'ui-component.yml',
+          filePath: '/contracts/ui-component.yml',
+          currentHash: 'hash-frontend',
+          storedHash: null,
+          status: 'added' as const,
+        },
+      ],
+    };
+
     await page.route('**/api/contracts', async (route) => {
       await route.fulfill(mockApiResponses.success(mockContracts.mixedCategoryContracts));
+    });
+
+    await page.route('**/api/contracts/check-if-contract-modified', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mixedModifiedContracts),
+      });
     });
 
     await contractsPage.navigate();

--- a/frontend/tests/contracts-list.spec.ts
+++ b/frontend/tests/contracts-list.spec.ts
@@ -142,8 +142,8 @@ test.describe('Contracts List Page', () => {
     await contractsPage.navigate();
     await contractsPage.waitForContractsToLoad();
 
-    // Verify error alert is displayed
-    const errorAlert = new Alert(contractsPage.errorAlert);
+    // Verify check-modified error alert is displayed
+    const errorAlert = new Alert(contractsPage.checkModifiedErrorAlert);
     await errorAlert.verifyIsVisible();
     await errorAlert.verifyText('Error checking contract modifications');
   });

--- a/frontend/tests/pages/ContractsListPage.ts
+++ b/frontend/tests/pages/ContractsListPage.ts
@@ -26,10 +26,10 @@ export class ContractsListPage extends BasePage {
     this.pageTitle = page.getByRole('heading', { name: 'AI Contracts System', level: 1 });
     this.pageSubtitle = page.getByRole('heading', { name: 'AI Coder Agent Contract Systems', level: 5 });
     this.contractsCard = page.locator('.MuiCard-root').first();
-    this.contractsCardTitle = page.getByRole('heading', { name: '📋 Contracts List' });
+    this.contractsCardTitle = page.getByRole('heading', { name: '📋 Modified/New Contracts' });
     this.loadingSpinner = page.getByRole('progressbar');
     this.errorAlert = page.locator('[role="alert"]').filter({ hasText: 'Error loading contracts' });
-    this.noContractsAlert = page.locator('[role="alert"]').filter({ hasText: 'No contracts found' });
+    this.noContractsAlert = page.locator('[role="alert"]').filter({ hasText: 'No modified or new contracts found' });
     this.contractCards = page.getByTestId('contract-card');
     this.verifyContractsButton = page.getByTestId('verify-contracts-button');
     this.checkModifiedErrorAlert = page.locator('[role="alert"]').filter({ hasText: 'Error checking contract modifications' });


### PR DESCRIPTION
Filter contracts on the main page to display only modified or new contracts and add visual status indicators, fulfilling PIA-60 requirements.

---
Linear Issue: [PIA-60](https://linear.app/piarsoftware/issue/PIA-60/only-modifiednew-contracts-on-main-page)

<a href="https://cursor.com/background-agent?bcId=bc-bd522d1d-f231-46db-8192-7c8430c0a754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bd522d1d-f231-46db-8192-7c8430c0a754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

