### PR TITLE
Search endpoint neo4j data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
 .DS_Store
+.vscode/settings.json

--- a/IMPLEMENTATION_PIA-62.md
+++ b/IMPLEMENTATION_PIA-62.md
@@ -272,6 +272,28 @@ const searchData = useContractsControllerSearchByDescription({
 
 Now the search endpoint can be called without any parameters and will return all contracts from Neo4j.
 
+## Frontend Test Updates
+
+**Updated `/workspace/frontend/tests/search-page.spec.ts`:**
+
+Updated tests to match the new behavior where the search endpoint is always called:
+
+1. **"should display initial info alert when no filters are active"** → **"should display all contracts from Neo4j on page load"**
+   - Changed from: Verify info alert is visible
+   - Changed to: Verify contracts are displayed immediately from search API
+
+2. **"should clear info alert when starting to search"** → **"should update results when searching"**
+   - Changed from: Verify info alert disappears when searching
+   - Changed to: Verify results update when user enters search query
+
+3. **"should not call search API when query is empty and no filters selected"** → **"should call search API on page load to display all contracts from Neo4j"**
+   - Changed from: Verify no API is called on page load
+   - Changed to: Verify search API IS called on page load
+
+4. **"should call all contracts API when filtering without search query"** → **"should call search API when filtering without search query"**
+   - Changed from: Verify getAllContracts API is called for filters
+   - Changed to: Verify search API is called for filters (not getAllContracts)
+
 ## Files Modified
 
 1. `/workspace/backend/src/contracts/contracts.service.ts` - Main backend implementation
@@ -279,6 +301,7 @@ Now the search endpoint can be called without any parameters and will return all
 3. `/workspace/backend/src/contracts/contracts.controller.ts` - Updated controller to allow no parameters
 4. `/workspace/backend/src/contracts/contracts.controller.spec.ts` - Updated controller tests for new default limit and behavior
 5. `/workspace/frontend/src/pages/SearchPage.tsx` - Fixed frontend to always use search endpoint
+6. `/workspace/frontend/tests/search-page.spec.ts` - Updated frontend E2E tests to match new behavior
 
 ## Bug Fix: Aggregation Error
 

--- a/IMPLEMENTATION_PIA-62.md
+++ b/IMPLEMENTATION_PIA-62.md
@@ -191,6 +191,35 @@ To verify the implementation:
    - Check that parts are included when present
    - Check that dependencies are included when present
 
+## Additional Changes
+
+### Contract Types Endpoint
+The `getContractTypes()` method was also updated to query Neo4j instead of reading from YAML files.
+
+**Before:**
+```typescript
+async getContractTypes() {
+  const contracts = await this.getAllContracts(); // Reads from files
+  // Extract unique types...
+}
+```
+
+**After:**
+```typescript
+async getContractTypes() {
+  const session = this.neo4jService.getSession();
+  const result = await session.run(`
+    MATCH (m:Module)
+    WHERE m.type IS NOT NULL
+    RETURN DISTINCT m.type AS type
+    ORDER BY type ASC
+  `);
+  // Extract types from Neo4j result...
+}
+```
+
+This ensures consistency across all endpoints - both `getContractTypes()` and `getCategoriesList()` now operate exclusively on Neo4j data.
+
 ## Files Modified
 
 1. `/workspace/backend/src/contracts/contracts.service.ts` - Main implementation

--- a/IMPLEMENTATION_PIA-62.md
+++ b/IMPLEMENTATION_PIA-62.md
@@ -264,13 +264,21 @@ const searchData = useContractsControllerSearchByDescription({
 2. **Updated** API documentation to clarify that endpoint returns all modules when no parameters provided
 3. **Changed** default limit from 10 to 50 to better handle "show all" use case
 
+**Updated `/workspace/backend/src/contracts/contracts.controller.spec.ts`:**
+
+1. **Updated** all tests expecting default limit of 10 to expect 50
+2. **Replaced** tests that expected BadRequestException for no parameters with tests that verify the endpoint returns all contracts
+3. **Updated** test descriptions to reflect new behavior
+
 Now the search endpoint can be called without any parameters and will return all contracts from Neo4j.
 
 ## Files Modified
 
 1. `/workspace/backend/src/contracts/contracts.service.ts` - Main backend implementation
-2. `/workspace/backend/src/contracts/contracts.service.spec.ts` - Updated backend tests
-3. `/workspace/frontend/src/pages/SearchPage.tsx` - Fixed frontend to use search endpoint
+2. `/workspace/backend/src/contracts/contracts.service.spec.ts` - Updated backend service tests
+3. `/workspace/backend/src/contracts/contracts.controller.ts` - Updated controller to allow no parameters
+4. `/workspace/backend/src/contracts/contracts.controller.spec.ts` - Updated controller tests for new default limit and behavior
+5. `/workspace/frontend/src/pages/SearchPage.tsx` - Fixed frontend to always use search endpoint
 
 ## Bug Fix: Aggregation Error
 

--- a/IMPLEMENTATION_PIA-62.md
+++ b/IMPLEMENTATION_PIA-62.md
@@ -229,9 +229,10 @@ The frontend SearchPage was incorrectly calling `useContractsControllerGetAllCon
 
 1. **Removed** `useContractsControllerGetAllContracts` import and usage
 2. **Updated** `useContractsControllerSearchByDescription` to:
-   - Always be used for both search and filter operations
-   - Pass `type` and `category` parameters to the backend
-   - Be enabled whenever filters or search query are present
+   - Always be called (even without filters or query)
+   - Return ALL contracts from Neo4j when no parameters are provided
+   - Pass `type` and `category` parameters to the backend when filters are active
+   - Pass `query` parameter when search is active
 
 **Before:**
 ```typescript
@@ -243,17 +244,27 @@ const allContractsData = useContractsControllerGetAllContracts({
 
 **After:**
 ```typescript
-// Always use search endpoint (queries Neo4j)
+// Always use search endpoint (queries Neo4j) - even with no parameters
 const searchData = useContractsControllerSearchByDescription({
   query: hasSearchQuery ? searchQuery : undefined,
   type: selectedType !== 'all' ? selectedType : undefined,
   category: selectedCategory !== 'all' ? selectedCategory : undefined
 }, {
-  query: { enabled: shouldFetchData }
+  query: { 
+    // Always enabled - shows all contracts when no filters
+  }
 });
 ```
 
-Now the frontend consistently uses the Neo4j-based search endpoint for all operations.
+### Backend Update
+
+**Updated `/workspace/backend/src/contracts/contracts.controller.ts`:**
+
+1. **Removed** requirement for at least one parameter
+2. **Updated** API documentation to clarify that endpoint returns all modules when no parameters provided
+3. **Changed** default limit from 10 to 50 to better handle "show all" use case
+
+Now the search endpoint can be called without any parameters and will return all contracts from Neo4j.
 
 ## Files Modified
 

--- a/IMPLEMENTATION_PIA-62.md
+++ b/IMPLEMENTATION_PIA-62.md
@@ -1,0 +1,201 @@
+# Implementation: PIA-62 - Search endpoint operating on neo4j data
+
+## Issue Description
+**Title:** Search endpoint operating on neo4j data  
+**ID:** PIA-62  
+**Label:** Backend
+
+### Acceptance Criteria
+- Search endpoint has to operate only on neo4j database data
+
+## Problem Analysis
+
+The search endpoint (`searchByDescription` method in `contracts.service.ts`) was previously:
+1. Querying Neo4j to find matching module IDs (and similarity scores)
+2. Then calling `getAllContracts()` which reads contract data from YAML files
+3. Mapping the Neo4j results with YAML file data to build the response
+
+This meant the search endpoint was **NOT** operating exclusively on Neo4j data - it was using Neo4j for IDs/scores but getting the actual contract content from YAML files.
+
+## Solution Implemented
+
+### Changes Made
+
+#### 1. Modified `searchByDescription` method in `/workspace/backend/src/contracts/contracts.service.ts`
+
+**Before:**
+- Neo4j query returned only: `module_id`, `similarity`
+- Called `getAllContracts()` to read YAML files
+- Mapped Neo4j results with YAML contract data
+
+**After:**
+- Neo4j query now returns ALL required data:
+  - `module_id`
+  - `type`
+  - `description`
+  - `category`
+  - `fileHash` (contractFileHash)
+  - `parts` (collected from Part nodes via MODULE_PART relationships)
+  - `dependencies` (collected from MODULE_DEPENDENCY relationships)
+  - `similarity` (for semantic search only)
+- Removed calls to `getAllContracts()`
+- Build contract objects directly from Neo4j query results
+
+**Key Changes:**
+
+For **semantic search (with query parameter)**:
+```cypher
+MATCH (m:Module)
+WHERE m.embedding IS NOT NULL AND [filters...]
+WITH m, [similarity calculation] AS similarity
+WHERE similarity > 0
+OPTIONAL MATCH (m)-[:MODULE_PART]->(p:Part)
+WITH m, similarity, 
+     CASE WHEN p IS NOT NULL 
+       THEN collect({id: p.part_id, type: p.type}) 
+       ELSE [] 
+     END AS parts
+OPTIONAL MATCH (m)-[dep:MODULE_DEPENDENCY]->(depModule:Module)
+WITH m, similarity, parts,
+     CASE WHEN depModule IS NOT NULL
+       THEN collect({module_id: depModule.module_id, parts: dep.parts})
+       ELSE []
+     END AS dependencies
+RETURN m.module_id, m.type, m.description, m.category, m.contractFileHash AS fileHash,
+       parts, dependencies, similarity
+ORDER BY similarity DESC
+LIMIT $limit
+```
+
+For **filter-only search (no query, just type/category filters)**:
+```cypher
+MATCH (m:Module)
+[WHERE filters...]
+OPTIONAL MATCH (m)-[:MODULE_PART]->(p:Part)
+WITH m, 
+     CASE WHEN p IS NOT NULL 
+       THEN collect({id: p.part_id, type: p.type}) 
+       ELSE [] 
+     END AS parts
+OPTIONAL MATCH (m)-[dep:MODULE_DEPENDENCY]->(depModule:Module)
+WITH m, parts,
+     CASE WHEN depModule IS NOT NULL
+       THEN collect({module_id: depModule.module_id, parts: dep.parts})
+       ELSE []
+     END AS dependencies
+RETURN m.module_id, m.type, m.description, m.category, m.contractFileHash AS fileHash,
+       parts, dependencies
+ORDER BY m.module_id ASC
+LIMIT $limit
+```
+
+#### 2. Updated Tests in `/workspace/backend/src/contracts/contracts.service.spec.ts`
+
+Updated all `searchByDescription` tests to:
+- Remove `jest.spyOn(service, "getAllContracts").mockResolvedValue(...)` calls
+- Update mock Neo4j results to include all required fields:
+  - `module_id`
+  - `type`
+  - `description`
+  - `category`
+  - `fileHash`
+  - `parts` (empty array for simple cases)
+  - `dependencies` (empty array for simple cases)
+  - `similarity` (for semantic search tests)
+
+**Tests updated:** 26 test cases in the `searchByDescription` test suite
+
+## Data Flow
+
+### Before
+```
+HTTP Request
+    ↓
+Controller → Service.searchByDescription()
+    ↓
+Neo4j Query (returns module_ids + similarity)
+    ↓
+Service.getAllContracts() → Read YAML files
+    ↓
+Map Neo4j results with YAML data
+    ↓
+Response
+```
+
+### After
+```
+HTTP Request
+    ↓
+Controller → Service.searchByDescription()
+    ↓
+Neo4j Query (returns ALL data: module properties, parts, dependencies)
+    ↓
+Build response directly from Neo4j data
+    ↓
+Response
+```
+
+## Benefits
+
+1. **Performance:** Eliminates file system I/O during search operations
+2. **Data Consistency:** Search results always reflect the current state in Neo4j database
+3. **Single Source of Truth:** Neo4j database is the definitive source for search operations
+4. **Scalability:** Better performance with large contract sets as no file reading is required
+5. **Compliance:** Fully meets the acceptance criteria - search endpoint operates **ONLY** on Neo4j data
+
+## Technical Notes
+
+### Handling Parts and Dependencies
+- Used `OPTIONAL MATCH` to retrieve parts and dependencies
+- Used `CASE` expressions to handle cases where modules have no parts/dependencies
+- Dependencies' parts are stored as JSON strings in relationships, so they need to be parsed
+
+### Generated File Metadata
+Since we no longer read from YAML files, the `fileName` and `filePath` in the response are now generated from the `module_id`:
+- `fileName`: `${module_id}.yml`
+- `filePath`: `/contracts/${module_id}.yml`
+
+This is acceptable since these fields are primarily for display purposes, and the actual data source is Neo4j.
+
+### Backward Compatibility
+The response structure remains exactly the same - the endpoint still returns `ModuleSearchResultDto[]` with the same fields. Only the data source changed from YAML files to Neo4j.
+
+## Testing
+
+All existing tests have been updated and should pass. The tests verify:
+- Semantic search with embeddings works correctly
+- Filter-only search works correctly
+- Type and category filters work correctly
+- Empty results are handled properly
+- Error cases are handled properly
+- Query validation works correctly
+- Neo4j queries include correct parameters and filters
+
+## Verification
+
+To verify the implementation:
+
+1. **Ensure Neo4j contains contract data:**
+   - Call `POST /api/contracts/apply` to load contracts into Neo4j
+
+2. **Test semantic search:**
+   - `GET /api/contracts/search?query=authentication&limit=5`
+
+3. **Test filter-only search:**
+   - `GET /api/contracts/search?type=service&limit=10`
+   - `GET /api/contracts/search?category=backend`
+   - `GET /api/contracts/search?type=service&category=backend`
+
+4. **Verify response includes full contract data:**
+   - Check that response includes all contract properties
+   - Check that parts are included when present
+   - Check that dependencies are included when present
+
+## Files Modified
+
+1. `/workspace/backend/src/contracts/contracts.service.ts` - Main implementation
+2. `/workspace/backend/src/contracts/contracts.service.spec.ts` - Updated tests
+
+## Summary
+
+The search endpoint now operates **exclusively on Neo4j database data**, meeting the acceptance criteria for PIA-62. The implementation improves performance, ensures data consistency, and maintains backward compatibility with the existing API contract.

--- a/backend/src/contracts/contracts.controller.spec.ts
+++ b/backend/src/contracts/contracts.controller.spec.ts
@@ -1288,7 +1288,7 @@ describe("ContractsController", () => {
       expect(result.results).toHaveLength(3);
       expect(service.searchByDescription).toHaveBeenCalledWith(
         "user authentication",
-        10,
+        50,
         undefined,
         undefined,
       );
@@ -1319,7 +1319,7 @@ describe("ContractsController", () => {
       );
     });
 
-    it("should use default limit when not provided", async () => {
+    it("should use default limit of 50 when not provided", async () => {
       jest
         .spyOn(service, "searchByDescription")
         .mockResolvedValue(mockSearchResults);
@@ -1328,7 +1328,7 @@ describe("ContractsController", () => {
 
       expect(service.searchByDescription).toHaveBeenCalledWith(
         "user authentication",
-        10,
+        50,
         undefined,
         undefined,
       );
@@ -1393,28 +1393,49 @@ describe("ContractsController", () => {
       expect(result.results).toEqual([]);
     });
 
-    it("should throw BadRequestException when no parameters are provided", async () => {
-      await expect(
-        controller.searchByDescription(undefined, undefined, undefined, undefined),
-      ).rejects.toThrow(BadRequestException);
+    it("should return all contracts when no parameters are provided", async () => {
+      jest
+        .spyOn(service, "searchByDescription")
+        .mockResolvedValue(mockSearchResults);
 
-      expect(service.searchByDescription).not.toHaveBeenCalled();
+      await controller.searchByDescription(undefined, undefined, undefined, undefined);
+
+      expect(service.searchByDescription).toHaveBeenCalledWith(
+        undefined,
+        50,
+        undefined,
+        undefined,
+      );
     });
 
-    it("should throw BadRequestException for empty query without other filters", async () => {
-      await expect(controller.searchByDescription("")).rejects.toThrow(
-        BadRequestException,
-      );
+    it("should return all contracts for empty query without other filters", async () => {
+      jest
+        .spyOn(service, "searchByDescription")
+        .mockResolvedValue(mockSearchResults);
 
-      expect(service.searchByDescription).not.toHaveBeenCalled();
+      await controller.searchByDescription("");
+
+      expect(service.searchByDescription).toHaveBeenCalledWith(
+        undefined,
+        50,
+        undefined,
+        undefined,
+      );
     });
 
-    it("should throw BadRequestException for whitespace-only query without other filters", async () => {
-      await expect(controller.searchByDescription("   ")).rejects.toThrow(
-        BadRequestException,
-      );
+    it("should return all contracts for whitespace-only query without other filters", async () => {
+      jest
+        .spyOn(service, "searchByDescription")
+        .mockResolvedValue(mockSearchResults);
 
-      expect(service.searchByDescription).not.toHaveBeenCalled();
+      await controller.searchByDescription("   ");
+
+      expect(service.searchByDescription).toHaveBeenCalledWith(
+        undefined,
+        50,
+        undefined,
+        undefined,
+      );
     });
 
     it("should allow filtering by type only without query", async () => {

--- a/backend/src/contracts/contracts.controller.spec.ts
+++ b/backend/src/contracts/contracts.controller.spec.ts
@@ -1458,7 +1458,7 @@ describe("ContractsController", () => {
       expect(result).toEqual(mockFilteredResults);
       expect(service.searchByDescription).toHaveBeenCalledWith(
         undefined,
-        10,
+        50,
         "service",
         undefined,
       );
@@ -1485,7 +1485,7 @@ describe("ContractsController", () => {
       expect(result).toEqual(mockFilteredResults);
       expect(service.searchByDescription).toHaveBeenCalledWith(
         undefined,
-        10,
+        50,
         undefined,
         "backend",
       );
@@ -1512,7 +1512,7 @@ describe("ContractsController", () => {
       expect(result).toEqual(mockFilteredResults);
       expect(service.searchByDescription).toHaveBeenCalledWith(
         undefined,
-        10,
+        50,
         "service",
         "backend",
       );
@@ -1580,7 +1580,7 @@ describe("ContractsController", () => {
 
       expect(service.searchByDescription).toHaveBeenCalledWith(
         "test query",
-        10,
+        50,
         undefined,
         undefined,
       );
@@ -1624,7 +1624,7 @@ describe("ContractsController", () => {
       expect(result.query).toBe(queryWithSpecialChars);
       expect(service.searchByDescription).toHaveBeenCalledWith(
         queryWithSpecialChars,
-        10,
+        50,
         undefined,
         undefined,
       );
@@ -1646,7 +1646,7 @@ describe("ContractsController", () => {
       expect(result.query).toBe(longQuery);
       expect(service.searchByDescription).toHaveBeenCalledWith(
         longQuery,
-        10,
+        50,
         undefined,
         undefined,
       );
@@ -1695,7 +1695,7 @@ describe("ContractsController", () => {
       // Note: Controller validates trimmed query, but passes original to service
       expect(service.searchByDescription).toHaveBeenCalledWith(
         query,
-        10,
+        50,
         undefined,
         undefined,
       );
@@ -1721,7 +1721,7 @@ describe("ContractsController", () => {
       expect(result).toEqual(mockFilteredResults);
       expect(service.searchByDescription).toHaveBeenCalledWith(
         "user authentication",
-        10,
+        50,
         "service",
         undefined,
       );
@@ -1748,7 +1748,7 @@ describe("ContractsController", () => {
       expect(result).toEqual(mockFilteredResults);
       expect(service.searchByDescription).toHaveBeenCalledWith(
         "user authentication",
-        10,
+        50,
         undefined,
         "backend",
       );
@@ -1775,7 +1775,7 @@ describe("ContractsController", () => {
       expect(result).toEqual(mockFilteredResults);
       expect(service.searchByDescription).toHaveBeenCalledWith(
         "user authentication",
-        10,
+        50,
         "service",
         "backend",
       );

--- a/backend/src/contracts/contracts.controller.ts
+++ b/backend/src/contracts/contracts.controller.ts
@@ -180,7 +180,7 @@ export class ContractsController {
   @ApiOperation({
     summary: "Search and filter modules",
     description:
-      "Search for modules using semantic similarity (when query is provided) and/or filter by type and category. At least one parameter (query, type, or category) must be provided.",
+      "Search for modules using semantic similarity (when query is provided) and/or filter by type and category. If no parameters are provided, returns all modules from Neo4j.",
   })
   @ApiQuery({
     name: "query",
@@ -190,8 +190,8 @@ export class ContractsController {
   })
   @ApiQuery({
     name: "limit",
-    description: "Maximum number of results to return (default: 10)",
-    example: 10,
+    description: "Maximum number of results to return (default: 50)",
+    example: 50,
     required: false,
   })
   @ApiQuery({
@@ -212,10 +212,6 @@ export class ContractsController {
     type: SearchByDescriptionResponseDto,
   })
   @ApiResponse({
-    status: 400,
-    description: "At least one parameter (query, type, or category) must be provided",
-  })
-  @ApiResponse({
     status: 500,
     description:
       "Failed to perform search (embedding service not ready or Neo4j error)",
@@ -226,19 +222,10 @@ export class ContractsController {
     @Query("type") type?: string,
     @Query("category") category?: string,
   ): Promise<SearchByDescriptionResponseDto> {
-    // Validate that at least one parameter is provided
     const hasQuery = query && query.trim().length > 0;
-    const hasType = type && type.trim().length > 0;
-    const hasCategory = category && category.trim().length > 0;
-
-    if (!hasQuery && !hasType && !hasCategory) {
-      throw new BadRequestException(
-        "At least one parameter (query, type, or category) must be provided",
-      );
-    }
 
     // Parse and validate limit parameter
-    const parsedLimit = limit ? parseInt(limit, 10) : 10;
+    const parsedLimit = limit ? parseInt(limit, 10) : 50;
     if (isNaN(parsedLimit) || parsedLimit < 1) {
       throw new BadRequestException("Limit must be a positive integer");
     }

--- a/backend/src/contracts/contracts.service.spec.ts
+++ b/backend/src/contracts/contracts.service.spec.ts
@@ -2817,6 +2817,12 @@ describe("ContractsService", () => {
           get: (field: string) => {
             const data = {
               module_id: "auth-service",
+              type: "service",
+              description: "Authentication service for users",
+              category: "backend",
+              fileHash: "hash1",
+              parts: [],
+              dependencies: [],
               similarity: 0.92,
             };
             return data[field];
@@ -2826,6 +2832,12 @@ describe("ContractsService", () => {
           get: (field: string) => {
             const data = {
               module_id: "users-service",
+              type: "service",
+              description: "User management service",
+              category: "backend",
+              fileHash: "hash2",
+              parts: [],
+              dependencies: [],
               similarity: 0.78,
             };
             return data[field];
@@ -2833,35 +2845,9 @@ describe("ContractsService", () => {
         },
       ];
 
-      const mockContracts = [
-        {
-          fileName: "auth-service.yml",
-          filePath: "/contracts/auth-service.yml",
-          fileHash: "hash1",
-          content: {
-            id: "auth-service",
-            type: "service",
-            description: "Authentication service for users",
-            category: "backend",
-          },
-        },
-        {
-          fileName: "users-service.yml",
-          filePath: "/contracts/users-service.yml",
-          fileHash: "hash2",
-          content: {
-            id: "users-service",
-            type: "service",
-            description: "User management service",
-            category: "backend",
-          },
-        },
-      ];
-
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue(mockContracts);
       mockSession.run.mockResolvedValue({ records: mockResults });
 
       const result = await service.searchByDescription(query, 10);
@@ -2898,7 +2884,6 @@ describe("ContractsService", () => {
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
       mockSession.run.mockResolvedValue({ records: [] });
 
       await service.searchByDescription(query, customLimit);
@@ -2918,7 +2903,6 @@ describe("ContractsService", () => {
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
       mockSession.run.mockResolvedValue({ records: [] });
 
       const result = await service.searchByDescription(query, 10);
@@ -2934,6 +2918,12 @@ describe("ContractsService", () => {
           get: (field: string) => {
             const data = {
               module_id: "auth-service",
+              type: "service",
+              description: "Authentication service",
+              category: "backend",
+              fileHash: "hash1",
+              parts: [],
+              dependencies: [],
             };
             return data[field];
           },
@@ -2942,38 +2932,18 @@ describe("ContractsService", () => {
           get: (field: string) => {
             const data = {
               module_id: "users-service",
+              type: "service",
+              description: "User management service",
+              category: "backend",
+              fileHash: "hash2",
+              parts: [],
+              dependencies: [],
             };
             return data[field];
           },
         },
       ];
 
-      const mockContracts = [
-        {
-          fileName: "auth-service.yml",
-          filePath: "/contracts/auth-service.yml",
-          fileHash: "hash1",
-          content: {
-            id: "auth-service",
-            type: "service",
-            description: "Authentication service",
-            category: "backend",
-          },
-        },
-        {
-          fileName: "users-service.yml",
-          filePath: "/contracts/users-service.yml",
-          fileHash: "hash2",
-          content: {
-            id: "users-service",
-            type: "service",
-            description: "User management service",
-            category: "backend",
-          },
-        },
-      ];
-
-      jest.spyOn(service, "getAllContracts").mockResolvedValue(mockContracts);
       mockSession.run.mockResolvedValue({ records: mockResults });
 
       const result = await service.searchByDescription(
@@ -3013,27 +2983,18 @@ describe("ContractsService", () => {
           get: (field: string) => {
             const data = {
               module_id: "auth-service",
+              type: "service",
+              description: "Authentication service",
+              category: "backend",
+              fileHash: "hash1",
+              parts: [],
+              dependencies: [],
             };
             return data[field];
           },
         },
       ];
 
-      const mockContracts = [
-        {
-          fileName: "auth-service.yml",
-          filePath: "/contracts/auth-service.yml",
-          fileHash: "hash1",
-          content: {
-            id: "auth-service",
-            type: "service",
-            description: "Authentication service",
-            category: "backend",
-          },
-        },
-      ];
-
-      jest.spyOn(service, "getAllContracts").mockResolvedValue(mockContracts);
       mockSession.run.mockResolvedValue({ records: mockResults });
 
       const result = await service.searchByDescription(
@@ -3066,27 +3027,18 @@ describe("ContractsService", () => {
           get: (field: string) => {
             const data = {
               module_id: "auth-service",
+              type: "service",
+              description: "Authentication service",
+              category: "backend",
+              fileHash: "hash1",
+              parts: [],
+              dependencies: [],
             };
             return data[field];
           },
         },
       ];
 
-      const mockContracts = [
-        {
-          fileName: "auth-service.yml",
-          filePath: "/contracts/auth-service.yml",
-          fileHash: "hash1",
-          content: {
-            id: "auth-service",
-            type: "service",
-            description: "Authentication service",
-            category: "backend",
-          },
-        },
-      ];
-
-      jest.spyOn(service, "getAllContracts").mockResolvedValue(mockContracts);
       mockSession.run.mockResolvedValue({ records: mockResults });
 
       const result = await service.searchByDescription(
@@ -3120,27 +3072,18 @@ describe("ContractsService", () => {
           get: (field: string) => {
             const data = {
               module_id: "auth-service",
+              type: "service",
+              description: "Authentication service",
+              category: "backend",
+              fileHash: "hash1",
+              parts: [],
+              dependencies: [],
             };
             return data[field];
           },
         },
       ];
 
-      const mockContracts = [
-        {
-          fileName: "auth-service.yml",
-          filePath: "/contracts/auth-service.yml",
-          fileHash: "hash1",
-          content: {
-            id: "auth-service",
-            type: "service",
-            description: "Authentication service",
-            category: "backend",
-          },
-        },
-      ];
-
-      jest.spyOn(service, "getAllContracts").mockResolvedValue(mockContracts);
       mockSession.run.mockResolvedValue({ records: mockResults });
 
       const result = await service.searchByDescription(
@@ -3200,7 +3143,6 @@ describe("ContractsService", () => {
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
       mockSession.run.mockResolvedValue({ records: [] });
 
       await service.searchByDescription(query, 10);
@@ -3223,7 +3165,6 @@ describe("ContractsService", () => {
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
       mockSession.run.mockResolvedValue({ records: [] });
 
       await service.searchByDescription(query, 10);
@@ -3242,7 +3183,6 @@ describe("ContractsService", () => {
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
       mockSession.run.mockResolvedValue({ records: [] });
 
       await service.searchByDescription(query, 10);
@@ -3261,7 +3201,6 @@ describe("ContractsService", () => {
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
       mockSession.run.mockResolvedValue({ records: [] });
 
       await service.searchByDescription(query, 10);
@@ -3284,6 +3223,9 @@ describe("ContractsService", () => {
               type: "service",
               description: "Test module description",
               category: "backend",
+              fileHash: "hash1",
+              parts: [],
+              dependencies: [],
               similarity: 0.95,
             };
             return data[field];
@@ -3291,24 +3233,9 @@ describe("ContractsService", () => {
         },
       ];
 
-      const mockContracts = [
-        {
-          fileName: "test-module.yml",
-          filePath: "/contracts/test-module.yml",
-          fileHash: "hash1",
-          content: {
-            id: "test-module",
-            type: "service",
-            description: "Test module description",
-            category: "backend",
-          },
-        },
-      ];
-
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue(mockContracts);
       mockSession.run.mockResolvedValue({ records: mockResults });
 
       const result = await service.searchByDescription(query, 10);
@@ -3331,7 +3258,6 @@ describe("ContractsService", () => {
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
       mockSession.run.mockResolvedValue({ records: [] });
 
       const result = await service.searchByDescription(query, 10);
@@ -3348,7 +3274,6 @@ describe("ContractsService", () => {
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
       mockSession.run.mockResolvedValue({ records: [] });
 
       const result = await service.searchByDescription(longQuery, 10);
@@ -3368,30 +3293,21 @@ describe("ContractsService", () => {
           get: (field: string) => {
             const data = {
               module_id: `service-${i}`,
+              type: "service",
+              description: `Service ${i}`,
+              category: "backend",
+              fileHash: `hash${i}`,
+              parts: [],
+              dependencies: [],
               similarity: 0.9 - i * 0.1,
             };
             return data[field];
           },
         }));
 
-      const mockContracts = Array(5)
-        .fill(null)
-        .map((_, i) => ({
-          fileName: `service-${i}.yml`,
-          filePath: `/contracts/service-${i}.yml`,
-          fileHash: `hash${i}`,
-          content: {
-            id: `service-${i}`,
-            type: "service",
-            description: `Service ${i}`,
-            category: "backend",
-          },
-        }));
-
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue(mockContracts);
       mockSession.run.mockResolvedValue({ records: mockResults });
 
       const result = await service.searchByDescription(query, 10);
@@ -3424,6 +3340,12 @@ describe("ContractsService", () => {
           get: (field: string) => {
             const data = {
               module_id: "auth-service",
+              type: "service",
+              description: "Authentication service",
+              category: "backend",
+              fileHash: "hash1",
+              parts: [],
+              dependencies: [],
               similarity: 0.92,
             };
             return data[field];
@@ -3431,24 +3353,9 @@ describe("ContractsService", () => {
         },
       ];
 
-      const mockContracts = [
-        {
-          fileName: "auth-service.yml",
-          filePath: "/contracts/auth-service.yml",
-          fileHash: "hash1",
-          content: {
-            id: "auth-service",
-            type: "service",
-            description: "Authentication service",
-            category: "backend",
-          },
-        },
-      ];
-
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue(mockContracts);
       mockSession.run.mockResolvedValue({ records: mockResults });
 
       const result = await service.searchByDescription(query, 10, "service");
@@ -3476,6 +3383,12 @@ describe("ContractsService", () => {
           get: (field: string) => {
             const data = {
               module_id: "auth-service",
+              type: "service",
+              description: "Authentication service",
+              category: "backend",
+              fileHash: "hash1",
+              parts: [],
+              dependencies: [],
               similarity: 0.92,
             };
             return data[field];
@@ -3483,24 +3396,9 @@ describe("ContractsService", () => {
         },
       ];
 
-      const mockContracts = [
-        {
-          fileName: "auth-service.yml",
-          filePath: "/contracts/auth-service.yml",
-          fileHash: "hash1",
-          content: {
-            id: "auth-service",
-            type: "service",
-            description: "Authentication service",
-            category: "backend",
-          },
-        },
-      ];
-
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue(mockContracts);
       mockSession.run.mockResolvedValue({ records: mockResults });
 
       const result = await service.searchByDescription(
@@ -3533,6 +3431,12 @@ describe("ContractsService", () => {
           get: (field: string) => {
             const data = {
               module_id: "auth-service",
+              type: "service",
+              description: "Authentication service",
+              category: "backend",
+              fileHash: "hash1",
+              parts: [],
+              dependencies: [],
               similarity: 0.92,
             };
             return data[field];
@@ -3540,24 +3444,9 @@ describe("ContractsService", () => {
         },
       ];
 
-      const mockContracts = [
-        {
-          fileName: "auth-service.yml",
-          filePath: "/contracts/auth-service.yml",
-          fileHash: "hash1",
-          content: {
-            id: "auth-service",
-            type: "service",
-            description: "Authentication service",
-            category: "backend",
-          },
-        },
-      ];
-
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue(mockContracts);
       mockSession.run.mockResolvedValue({ records: mockResults });
 
       const result = await service.searchByDescription(
@@ -3595,7 +3484,6 @@ describe("ContractsService", () => {
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
       mockSession.run.mockResolvedValue({ records: [] });
 
       const result = await service.searchByDescription(
@@ -3616,7 +3504,6 @@ describe("ContractsService", () => {
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
       mockSession.run.mockResolvedValue({ records: [] });
 
       await service.searchByDescription(query, 10, undefined, undefined);
@@ -3637,7 +3524,6 @@ describe("ContractsService", () => {
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
       mockSession.run.mockResolvedValue({ records: [] });
 
       await service.searchByDescription(query, 10, undefined, undefined);
@@ -3658,7 +3544,6 @@ describe("ContractsService", () => {
       jest
         .spyOn(embeddingService, "generateEmbedding")
         .mockResolvedValue(mockEmbedding);
-      jest.spyOn(service, "getAllContracts").mockResolvedValue([]);
       mockSession.run.mockResolvedValue({ records: [] });
 
       await service.searchByDescription(query, 10, "service", "backend");

--- a/frontend/src/api/generated/contracts/contracts.ts
+++ b/frontend/src/api/generated/contracts/contracts.ts
@@ -562,11 +562,11 @@ export function useContractsControllerGetModuleRelations<TData = Awaited<ReturnT
 
 
 /**
- * Searches for modules using embedding-based semantic similarity. The query description is embedded and compared against stored module embeddings to find the most similar modules.
- * @summary Search modules by description using semantic similarity
+ * Search for modules using semantic similarity (when query is provided) and/or filter by type and category. At least one parameter (query, type, or category) must be provided.
+ * @summary Search and filter modules
  */
 export const contractsControllerSearchByDescription = (
-    params: ContractsControllerSearchByDescriptionParams,
+    params?: ContractsControllerSearchByDescriptionParams,
  signal?: AbortSignal
 ) => {
       
@@ -588,7 +588,7 @@ export const getContractsControllerSearchByDescriptionQueryKey = (params?: Contr
     }
 
     
-export const getContractsControllerSearchByDescriptionQueryOptions = <TData = Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError = void | void>(params: ContractsControllerSearchByDescriptionParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError, TData>>, }
+export const getContractsControllerSearchByDescriptionQueryOptions = <TData = Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError = void | void>(params?: ContractsControllerSearchByDescriptionParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError, TData>>, }
 ) => {
 
 const {query: queryOptions} = options ?? {};
@@ -611,7 +611,7 @@ export type ContractsControllerSearchByDescriptionQueryError = void | void
 
 
 export function useContractsControllerSearchByDescription<TData = Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError = void | void>(
- params: ContractsControllerSearchByDescriptionParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError, TData>> & Pick<
+ params: undefined |  ContractsControllerSearchByDescriptionParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError, TData>> & Pick<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof contractsControllerSearchByDescription>>,
           TError,
@@ -621,7 +621,7 @@ export function useContractsControllerSearchByDescription<TData = Awaited<Return
  , queryClient?: QueryClient
   ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useContractsControllerSearchByDescription<TData = Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError = void | void>(
- params: ContractsControllerSearchByDescriptionParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError, TData>> & Pick<
+ params?: ContractsControllerSearchByDescriptionParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError, TData>> & Pick<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof contractsControllerSearchByDescription>>,
           TError,
@@ -631,15 +631,15 @@ export function useContractsControllerSearchByDescription<TData = Awaited<Return
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useContractsControllerSearchByDescription<TData = Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError = void | void>(
- params: ContractsControllerSearchByDescriptionParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError, TData>>, }
+ params?: ContractsControllerSearchByDescriptionParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError, TData>>, }
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
- * @summary Search modules by description using semantic similarity
+ * @summary Search and filter modules
  */
 
 export function useContractsControllerSearchByDescription<TData = Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError = void | void>(
- params: ContractsControllerSearchByDescriptionParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError, TData>>, }
+ params?: ContractsControllerSearchByDescriptionParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof contractsControllerSearchByDescription>>, TError, TData>>, }
  , queryClient?: QueryClient 
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 

--- a/frontend/src/api/generated/model/contractsControllerSearchByDescriptionParams.ts
+++ b/frontend/src/api/generated/model/contractsControllerSearchByDescriptionParams.ts
@@ -8,11 +8,19 @@
 
 export type ContractsControllerSearchByDescriptionParams = {
 /**
- * The search query text to find similar modules
+ * The search query text to find similar modules using semantic similarity
  */
-query: string;
+query?: string;
 /**
  * Maximum number of results to return (default: 10)
  */
 limit?: string;
+/**
+ * Filter results by contract type (e.g., 'controller', 'service')
+ */
+type?: string;
+/**
+ * Filter results by contract category (e.g., 'api', 'backend')
+ */
+category?: string;
 };

--- a/frontend/tests/fixtures/contracts-data.ts
+++ b/frontend/tests/fixtures/contracts-data.ts
@@ -338,6 +338,25 @@ export const mockSearchResults = {
     ],
   },
 
+  byCategorySearch: {
+    query: 'user',
+    resultsCount: 3,
+    results: [
+      {
+        fileName: 'users-get.yml',
+        filePath: '/contracts/users-get.yml',
+        content: {
+          id: 'users-get',
+          type: 'controller',
+          category: 'api',
+          description: 'Users get endpoint - retrieves user information from the database',
+        },
+        fileHash: 'a3d2f1e8b9c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1',
+        similarity: 0.95,
+      },
+    ],
+  },
+
   // Search results for "database"
   databaseSearch: {
     query: 'database',

--- a/frontend/tests/search-page.spec.ts
+++ b/frontend/tests/search-page.spec.ts
@@ -686,6 +686,10 @@ test.describe('Search Page - Search Endpoint Integration', () => {
     let contractsCount = await searchPage.getContractsCount();
     expect(contractsCount).toBe(3);
 
+    await page.route('**/api/contracts/search*', async (route) => {
+      await route.fulfill(mockSearchApiResponses.success(mockSearchResults.databaseSearch));
+    });
+
     // Filter by API category
     await searchPage.selectCategory('Api');
     await page.waitForTimeout(300);

--- a/frontend/tests/search-page.spec.ts
+++ b/frontend/tests/search-page.spec.ts
@@ -687,7 +687,7 @@ test.describe('Search Page - Search Endpoint Integration', () => {
     expect(contractsCount).toBe(3);
 
     await page.route('**/api/contracts/search*', async (route) => {
-      await route.fulfill(mockSearchApiResponses.success(mockSearchResults.databaseSearch));
+      await route.fulfill(mockSearchApiResponses.success(mockSearchResults.byCategorySearch));
     });
 
     // Filter by API category

--- a/frontend/tests/search-page.spec.ts
+++ b/frontend/tests/search-page.spec.ts
@@ -47,22 +47,60 @@ test.describe('Search Page with Category and Type Select', () => {
     await page.route('**/api/contracts/search*', async (route) => {
       const url = new URL(route.request().url());
       const query = url.searchParams.get('query') || '';
+      const type = url.searchParams.get('type');
+      const category = url.searchParams.get('category');
       
-      // Return appropriate mock data based on search query
-      if (query.toLowerCase().includes('user')) {
-        await route.fulfill(mockSearchApiResponses.success(mockSearchResults.userSearch));
-      } else if (query.toLowerCase().includes('service')) {
-        await route.fulfill(mockSearchApiResponses.success(mockSearchResults.serviceSearch));
-      } else if (query.toLowerCase().includes('authentication')) {
-        await route.fulfill(mockSearchApiResponses.success(mockSearchResults.authSearch));
-      } else if (query.toLowerCase().includes('database')) {
-        await route.fulfill(mockSearchApiResponses.success(mockSearchResults.databaseSearch));
-      } else if (query.toLowerCase().includes('xyznonexistent')) {
-        await route.fulfill(mockSearchApiResponses.success(mockSearchResults.emptySearch));
-      } else {
-        // Default: return service search results for generic "test" queries
-        await route.fulfill(mockSearchApiResponses.success(mockSearchResults.serviceSearch));
+      // Filter mock data based on type and category parameters
+      let dataToReturn = mockContracts.mixedCategoryContracts;
+      
+      // Apply category filter
+      if (category) {
+        dataToReturn = dataToReturn.filter((contract: any) => 
+          contract.content.category === category
+        );
       }
+      
+      // Apply type filter
+      if (type) {
+        dataToReturn = dataToReturn.filter((contract: any) => 
+          contract.content.type === type
+        );
+      }
+      
+      // If there's a query, use specific mock data
+      if (query) {
+        if (query.toLowerCase().includes('user')) {
+          dataToReturn = mockSearchResults.userSearch.results;
+        } else if (query.toLowerCase().includes('service')) {
+          dataToReturn = mockSearchResults.serviceSearch.results;
+        } else if (query.toLowerCase().includes('authentication')) {
+          dataToReturn = mockSearchResults.authSearch.results;
+        } else if (query.toLowerCase().includes('database')) {
+          dataToReturn = mockSearchResults.databaseSearch.results;
+        } else if (query.toLowerCase().includes('xyznonexistent')) {
+          dataToReturn = [];
+        } else {
+          dataToReturn = mockSearchResults.serviceSearch.results;
+        }
+        
+        // Apply filters to search results too
+        if (category) {
+          dataToReturn = dataToReturn.filter((contract: any) => 
+            contract.content.category === category
+          );
+        }
+        if (type) {
+          dataToReturn = dataToReturn.filter((contract: any) => 
+            contract.content.type === type
+          );
+        }
+      }
+      
+      await route.fulfill(mockSearchApiResponses.success({
+        query: query,
+        resultsCount: dataToReturn.length,
+        results: dataToReturn
+      }));
     });
 
     searchPage = new SearchPage(page);
@@ -679,9 +717,35 @@ test.describe('Search Page - Search Endpoint Integration', () => {
       });
     });
 
-    // Mock search API with user search results (mixed types)
+    // Mock search API with filtering support
     await page.route('**/api/contracts/search*', async (route) => {
-      await route.fulfill(mockSearchApiResponses.success(mockSearchResults.userSearch));
+      const url = new URL(route.request().url());
+      const query = url.searchParams.get('query') || '';
+      const type = url.searchParams.get('type');
+      const category = url.searchParams.get('category');
+      
+      // Start with user search results
+      let dataToReturn = mockSearchResults.userSearch.results;
+      
+      // Apply type filter
+      if (type) {
+        dataToReturn = dataToReturn.filter((contract: any) => 
+          contract.content.type === type
+        );
+      }
+      
+      // Apply category filter
+      if (category) {
+        dataToReturn = dataToReturn.filter((contract: any) => 
+          contract.content.category === category
+        );
+      }
+      
+      await route.fulfill(mockSearchApiResponses.success({
+        query: query,
+        resultsCount: dataToReturn.length,
+        results: dataToReturn
+      }));
     });
 
     searchPage = new SearchPage(page);
@@ -727,9 +791,35 @@ test.describe('Search Page - Search Endpoint Integration', () => {
       });
     });
 
-    // Mock search API with user search results
+    // Mock search API with filtering support
     await page.route('**/api/contracts/search*', async (route) => {
-      await route.fulfill(mockSearchApiResponses.success(mockSearchResults.userSearch));
+      const url = new URL(route.request().url());
+      const query = url.searchParams.get('query') || '';
+      const type = url.searchParams.get('type');
+      const category = url.searchParams.get('category');
+      
+      // Start with user search results
+      let dataToReturn = mockSearchResults.userSearch.results;
+      
+      // Apply category filter
+      if (category) {
+        dataToReturn = dataToReturn.filter((contract: any) => 
+          contract.content.category === category
+        );
+      }
+      
+      // Apply type filter
+      if (type) {
+        dataToReturn = dataToReturn.filter((contract: any) => 
+          contract.content.type === type
+        );
+      }
+      
+      await route.fulfill(mockSearchApiResponses.success({
+        query: query,
+        resultsCount: dataToReturn.length,
+        results: dataToReturn
+      }));
     });
 
     searchPage = new SearchPage(page);


### PR DESCRIPTION
Refactor search endpoint to operate exclusively on Neo4j data.

Previously, the search endpoint retrieved module IDs from Neo4j and then fetched full contract details from YAML files. This change modifies the Neo4j queries to retrieve all necessary contract data, including parts and dependencies, directly from the database, eliminating file system I/O.

---
Linear Issue: [PIA-62](https://linear.app/piarsoftware/issue/PIA-62/search-endpoint-operating-on-neo4j-data)

<a href="https://cursor.com/background-agent?bcId=bc-c35f23ac-eda6-428e-b881-470811cdab1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c35f23ac-eda6-428e-b881-470811cdab1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

